### PR TITLE
Fix missing NN age groups in 2.1 V&V; add my output processing files from LSFF project

### DIFF
--- a/nathaniel/model_validation/ciff_output_processing.py
+++ b/nathaniel/model_validation/ciff_output_processing.py
@@ -125,6 +125,22 @@ def rate_or_ratio(numerator, denominator,
     
     return rate_or_ratio.reset_index()
 
+def divide(numerator:pd.DataFrame, denominator:pd.DataFrame, strata:list, extra_numerator_strata=None, broadcast_cols=None)-> pd.DataFrame: # or just numerator_broadcast instead of having two separate arguments
+    index_cols = INDEX_COLUMNS
+
+    if extra_numerator_strata is None:
+        extra_numerator_strata = []
+
+    if broadcast_cols is None:
+        broadcast_cols = []
+
+    numerator = numerator.groupby(strata+index_cols+extra_numerator_strata+broadcast_cols)[VALUE_COLUMN].sum()
+    denominator = denominator.groupby(strata+index_cols)[VALUE_COLUMN].sum()
+
+    rate_or_ratio = numerator / denominator
+
+    return rate_or_ratio.reset_index()
+
 def averted(measure, baseline_scenario, scenario_col=None):
     """
     Compute an "averted" measure (e.g. DALYs) or measures by subtracting

--- a/nathaniel/model_validation/ciff_output_processing.py
+++ b/nathaniel/model_validation/ciff_output_processing.py
@@ -1,0 +1,239 @@
+import pandas as pd
+
+VALUE_COLUMN = 'value'
+DRAW_COLUMN  = 'input_draw'
+SCENARIO_COLUMN = 'scenario'
+
+INDEX_COLUMNS = [DRAW_COLUMN, SCENARIO_COLUMN]
+
+def set_global_index_columns(index_columns:list)->None:
+    """
+    Set INDEX_COLUMNS to a custom list of columns for the Vivarium model output.
+    For example, if tables for different locations have been concatenated with
+    a new column called 'location', then use the following to get the correct
+    behavior for the functions in this module:
+    
+    set_global_index_columns(['location']+lsff_output_processing.INDEX_COLUMNS)
+    """
+    global INDEX_COLUMNS
+    INDEX_COLUMNS = index_columns
+
+def conditional_risk_of_ntds(
+    births_with_ntd: pd.DataFrame, 
+    live_births: pd.DataFrame, 
+    conditioned_on: list,
+    multiplier=1) -> pd.DataFrame:
+    """
+    Returns a dataframe with the contitional risk of neural tube defects
+    (measured by birth prevalence) in each subgroup in the specified
+    categories.
+    """
+    # Columns in both dataframes are:
+    # ['year', 'sex', 'fortification_group', 'measure', 'input_draw', 'scenario', 'value']
+    
+    # The index columns will NOT be aggregated over
+    index_columns = INDEX_COLUMNS + conditioned_on
+    
+    # In both dataframes, group by the index columns, and aggregate
+    #'value' column over remaining columns by summing
+    births_with_ntd = births_with_ntd.groupby(index_columns).value.sum()
+    live_births = live_births.groupby(index_columns).value.sum()
+    
+    # Divide the two pandas Series to get birth prevalence
+    # in each subgroup we conditioned on.
+    # Multiply by the multiplier to get desired units (e.g. per 1000 live births)
+    ntd_risk = multiplier * births_with_ntd / live_births
+    
+    # Drop any rows where we divided by 0 because there were no births
+    ntd_risk.dropna(inplace=True)
+    
+    return ntd_risk.reset_index()
+
+def rate_or_ratio(numerator, denominator,
+                  numerator_strata, denominator_strata,
+                  multiplier=1,
+                  broadcast_cols=None,
+                  dropna=False
+                 ):
+    """
+    Compute a rate or ratio by dividing the numerator by the denominator.
+    
+    Parameters
+    ----------
+    
+    numerator : DataFrame
+        The numerator data for the rate or ratio.
+        
+    denominator : DataFrame
+        The denominator data for the rate or ratio.
+        
+    numerator_strata : list of column names in numerator, or an empty list
+        Stratification variables to include in the numerator.
+        Strata in the denominator are automatically added to this list
+        since the population in the numerator must always be a subset of
+        the population in the denominator. (Thus an empty list [] defaults
+        to denominator_strata.)
+        
+     denominator_strata : list of column names in denominator
+         Stratification variables to include in the denominator.
+         These will automatically be added to numerator_strata.
+         
+     multiplier : int or float, default 1
+         Multiplier for the numerator, typically a power of 10,
+         to adjust the units of the result. For example, if computing a ratio,
+         some multipliers with corresponding units are:
+         1 - proportion
+         100 - percent
+         1000 - per thousand
+         100_000 - per hundred thousand
+         
+     broadcast_cols : list of column names in numerator
+         Columns in the numerator over which to broadcast. E.g. 'cause' to
+         compute a rate or ratio for multiple causes at once, or 'measure'
+         to compute a rate or ratio for multiple measures at once (like
+         deaths, ylls, and ylds).
+         
+     dropna : boolean, default False
+         Whether to drop rows with NaN values in the result, namely
+         if division by 0 occurs because of an empty stratum in the denominator.
+         
+     Returns
+     -------
+     rate_or_ratio : DataFrame
+         The rate or ratio data = numerator / denominator.
+    """
+    index_cols = INDEX_COLUMNS
+    
+    if broadcast_cols is None:
+        broadcast_cols = []
+
+    # When we divide, the numerator strata must contain the denominator strata,
+    # and the difference is the columns to broadcast over.
+    broadcast_cols = sorted(
+        set(numerator_strata) - set(denominator_strata),
+        key=numerator_strata.index
+    ) + broadcast_cols
+    
+    numerator = numerator.groupby(denominator_strata+index_cols+broadcast_cols)[VALUE_COLUMN].sum()
+    denominator = denominator.groupby(denominator_strata+index_cols)[VALUE_COLUMN].sum()
+    
+    rate_or_ratio = multiplier * numerator / denominator
+    
+    # If dropna is True, drop rows where we divided by 0
+    if dropna:
+        rate_or_ratio.dropna(inplace=True)
+    
+    return rate_or_ratio.reset_index()
+
+def averted(measure, baseline_scenario, scenario_col=None):
+    """
+    Compute an "averted" measure (e.g. DALYs) or measures by subtracting
+    the intervention value from the baseline value.
+    
+    Parameters
+    ----------
+    
+    measure : DataFrame
+        DataFrame containing both the baseline and intervention data.
+        
+    baseline_scenario : scalar, typically str
+        The name or other identifier for the baseline scenario in the
+        `scenario_col` column of the `measure` DataFrame.
+        
+    scenario_col : str, default None
+        The name of the scenario column in the `measure` DataFrame.
+        Defaults to the global parameter SCENARIO_COLUMN if None is passed.
+        
+    Returns
+    -------
+    
+    averted : DataFrame
+        The averted measure(s) = baseline - intervention
+    """
+    
+    scenario_col = SCENARIO_COLUMN if scenario_col is None else scenario_col
+    
+    # Filter to create separate dataframes for baseline and intervention
+    baseline = measure[measure[scenario_col] == baseline_scenario]
+    intervention = measure[measure[scenario_col] != baseline_scenario]
+    
+    # Columns to match when subtracting intervention from baseline
+    index_columns = sorted(set(baseline.columns) - set([scenario_col, VALUE_COLUMN]),
+                           key=baseline.columns.get_loc)
+    print(index_columns)
+    
+    # Put the scenario column in the index of intervention but not baseline.
+    # When we subtract, this will broadcast over different interventions if there are more than one.
+    baseline = baseline.set_index(index_columns)
+    intervention = intervention.set_index(index_columns+[scenario_col])
+    print('baseline index:', baseline.index.names)
+    print('intervention index:', intervention.index.names)
+    
+    # Get the averted values
+    averted = baseline[[VALUE_COLUMN]] - intervention[[VALUE_COLUMN]]
+    print('averted index:', averted.index.names)
+    
+    # Insert a column after the scenario column to record what the baseline scenario was
+    averted = averted.reset_index()
+    print(averted.columns)
+    averted.insert(averted.columns.get_loc(scenario_col)+1, 'relative_to', baseline_scenario)
+    
+    return averted
+
+def difference(measure:pd.DataFrame, identifier_col:str, minuend_id=None, subtrahend_id=None)->pd.DataFrame:
+    """
+    Returns the difference of a measure stored in the measure DataFrame, where the
+    rows for the minuend (that which is diminished) and subtrahend (that which is subtracted)
+    are determined by the values in identifier_col
+    """
+    if minuend_id is not None:
+        minuend = measure[measure[identifier_col] == minuend_id]
+        if subtrahend_id is not None:
+            subtrahend = measure[measure[identifier_col] == subtrahend_id]
+        else:
+            # Use all values not equal to minuend_id for subtrahend (minuend will be broadcast over subtrahend)
+            subtrahend = measure[measure[identifier_col] != minuend_id]
+    elif subtrahend_id is not None:
+        subtrahend = measure[measure[identifier_col] == subtrahend_id]
+        # Use all values not equal to subtrahend_id for minuend (subtrahend will be broadcast over minuend)
+        minuend = measure[measure[identifier_col] != subtrahend_id]
+    else:
+        raise ValueError("At least one of `minuend_id` and `subtrahend_id` must be specified")
+
+    # Columns to match when subtracting subtrahend from minuend
+    # Oh, I just noticed that I could use the Index.difference() method here, which I was unaware of before...
+    index_columns = sorted(set(measure.columns) - set([identifier_col, VALUE_COLUMN]),
+                           key=measure.columns.get_loc)
+
+    minuend = minuend.set_index(index_columns)
+    subtrahend = subtrahend.set_index(index_columns)
+
+    # Add the identifier column to the index of the larger dataframe
+    # (or default to the subtrahend dataframe if neither needs broadcasting).
+    if minuend_id is None:
+        minuend.set_index(identifier_col, append=True)
+    else:
+        subtrahend.set_index(identifier_col, append=True)
+
+    # Subtract DataFrames, not Series, because Series will drop the identifier column from the index
+    # if there is no broadcasting.
+    difference = minuend[[VALUE_COLUMN]] - subtrahend[[VALUE_COLUMN]]
+    difference = difference.reset_index()
+
+    # Add a column to specify what was subtracted from (the minuend) or what was subtracted (the subtrahend)
+    colname, value = 'subtracted_from', minuend_id if minuend_id is not None else 'subtracted_value', subtrahend_id
+    difference.insert(difference.columns.get_loc(identifier_col)+1, colname, value)
+
+    return difference
+
+def describe(data, **describe_kwargs):
+    """Wrapper function for DataFrame.describe() with `data` grouped by everything except draw and value."""
+    groupby_cols = [col for col in data.columns if col not in [DRAW_COLUMN, VALUE_COLUMN]]
+    return data.groupby(groupby_cols)[VALUE_COLUMN].describe(**describe_kwargs)
+
+def get_mean_lower_upper(described_data, colname_mapper={'mean':'mean', '2.5%':'lower', '97.5%':'upper'}):
+    """
+    Gets the mean, lower, and upper value from `described_data` DataFrame, which is assumed to have
+    the format resulting from a call to DataFrame.describe().
+    """
+    return described_data[colname_mapper.keys()].rename(columns=colname_mapper).reset_index()

--- a/nathaniel/model_validation/model2/2021_07_21_ciff_model_v2.1_wasting_risk_vv_2021_07_20_10_32_31_ndbs.ipynb
+++ b/nathaniel/model_validation/model2/2021_07_21_ciff_model_v2.1_wasting_risk_vv_2021_07_20_10_32_31_ndbs.ipynb
@@ -886,7 +886,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 70,
    "id": "a6acc1c8",
    "metadata": {},
    "outputs": [],
@@ -894,7 +894,7 @@
     "from vivarium import Artifact\n",
     "\n",
     "#explore the artifact data (note age groups)\n",
-    "art = Artifact('/ihme/costeffectiveness/artifacts/vivarium_ciff_sam/ethiopia.hdf', filter_terms=['year_start == 2019', 'age_start >=  0.076712', f'age_end <= 5'])"
+    "art = Artifact('/ihme/costeffectiveness/artifacts/vivarium_ciff_sam/ethiopia.hdf', filter_terms=['year_start == 2019', f'age_end <= 5'])"
    ]
   },
   {
@@ -912,7 +912,7 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "id": "1ae40ef1",
+   "id": "89e1d1f0",
    "metadata": {},
    "outputs": [
     {
@@ -1068,7 +1068,7 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "id": "2cbf4c6e",
+   "id": "7eb68163",
    "metadata": {},
    "outputs": [
     {
@@ -1265,7 +1265,7 @@
   {
    "cell_type": "code",
    "execution_count": 45,
-   "id": "a194c814",
+   "id": "f781b47f",
    "metadata": {},
    "outputs": [
     {
@@ -1286,7 +1286,7 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "id": "7ce7bdb0",
+   "id": "37a8d137",
    "metadata": {},
    "outputs": [
     {
@@ -1752,8 +1752,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
-   "id": "c9ef0e45",
+   "execution_count": 71,
+   "id": "4e14c0fd",
    "metadata": {},
    "outputs": [
     {
@@ -1795,60 +1795,60 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>female</td>\n",
-       "      <td>0.076712</td>\n",
-       "      <td>0.5</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.019178</td>\n",
        "      <td>2019</td>\n",
        "      <td>2020</td>\n",
-       "      <td>0.024987</td>\n",
-       "      <td>0.021183</td>\n",
-       "      <td>0.028627</td>\n",
-       "      <td>1-5_months</td>\n",
-       "      <td>3</td>\n",
+       "      <td>0.024557</td>\n",
+       "      <td>0.021287</td>\n",
+       "      <td>0.028370</td>\n",
+       "      <td>early_neonatal</td>\n",
+       "      <td>1</td>\n",
        "      <td>sam</td>\n",
        "      <td>prevalence</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>female</td>\n",
-       "      <td>0.076712</td>\n",
-       "      <td>0.5</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.019178</td>\n",
        "      <td>2019</td>\n",
        "      <td>2020</td>\n",
-       "      <td>0.083476</td>\n",
-       "      <td>0.079510</td>\n",
-       "      <td>0.087508</td>\n",
-       "      <td>1-5_months</td>\n",
-       "      <td>3</td>\n",
+       "      <td>0.082311</td>\n",
+       "      <td>0.078291</td>\n",
+       "      <td>0.086317</td>\n",
+       "      <td>early_neonatal</td>\n",
+       "      <td>1</td>\n",
        "      <td>mam</td>\n",
        "      <td>prevalence</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>female</td>\n",
-       "      <td>0.076712</td>\n",
-       "      <td>0.5</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.019178</td>\n",
        "      <td>2019</td>\n",
        "      <td>2020</td>\n",
-       "      <td>0.203717</td>\n",
-       "      <td>0.199215</td>\n",
-       "      <td>0.208915</td>\n",
-       "      <td>1-5_months</td>\n",
-       "      <td>3</td>\n",
+       "      <td>0.201385</td>\n",
+       "      <td>0.196609</td>\n",
+       "      <td>0.206213</td>\n",
+       "      <td>early_neonatal</td>\n",
+       "      <td>1</td>\n",
        "      <td>mild_wasting</td>\n",
        "      <td>prevalence</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>female</td>\n",
-       "      <td>0.076712</td>\n",
-       "      <td>0.5</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.019178</td>\n",
        "      <td>2019</td>\n",
        "      <td>2020</td>\n",
-       "      <td>0.687821</td>\n",
-       "      <td>0.679075</td>\n",
-       "      <td>0.695940</td>\n",
-       "      <td>1-5_months</td>\n",
-       "      <td>3</td>\n",
+       "      <td>0.691747</td>\n",
+       "      <td>0.683254</td>\n",
+       "      <td>0.700573</td>\n",
+       "      <td>early_neonatal</td>\n",
+       "      <td>1</td>\n",
        "      <td>tmrel_wasting</td>\n",
        "      <td>prevalence</td>\n",
        "    </tr>\n",
@@ -1868,10 +1868,10 @@
        "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>28</th>\n",
+       "      <th>44</th>\n",
        "      <td>male</td>\n",
-       "      <td>2.000000</td>\n",
-       "      <td>5.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>5.000000</td>\n",
        "      <td>2019</td>\n",
        "      <td>2020</td>\n",
        "      <td>0.016175</td>\n",
@@ -1883,10 +1883,10 @@
        "      <td>prevalence</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>29</th>\n",
+       "      <th>45</th>\n",
        "      <td>male</td>\n",
-       "      <td>2.000000</td>\n",
-       "      <td>5.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>5.000000</td>\n",
        "      <td>2019</td>\n",
        "      <td>2020</td>\n",
        "      <td>0.074177</td>\n",
@@ -1898,10 +1898,10 @@
        "      <td>prevalence</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>30</th>\n",
+       "      <th>46</th>\n",
        "      <td>male</td>\n",
-       "      <td>2.000000</td>\n",
-       "      <td>5.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>5.000000</td>\n",
        "      <td>2019</td>\n",
        "      <td>2020</td>\n",
        "      <td>0.210504</td>\n",
@@ -1913,10 +1913,10 @@
        "      <td>prevalence</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>31</th>\n",
+       "      <th>47</th>\n",
        "      <td>male</td>\n",
-       "      <td>2.000000</td>\n",
-       "      <td>5.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>5.000000</td>\n",
        "      <td>2019</td>\n",
        "      <td>2020</td>\n",
        "      <td>0.699143</td>\n",
@@ -1929,36 +1929,36 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>32 rows × 12 columns</p>\n",
+       "<p>48 rows × 12 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "       sex  age_start  age_end  year_start  year_end      mean      2.5%  \\\n",
-       "0   female   0.076712      0.5        2019      2020  0.024987  0.021183   \n",
-       "1   female   0.076712      0.5        2019      2020  0.083476  0.079510   \n",
-       "2   female   0.076712      0.5        2019      2020  0.203717  0.199215   \n",
-       "3   female   0.076712      0.5        2019      2020  0.687821  0.679075   \n",
-       "..     ...        ...      ...         ...       ...       ...       ...   \n",
-       "28    male   2.000000      5.0        2019      2020  0.016175  0.013549   \n",
-       "29    male   2.000000      5.0        2019      2020  0.074177  0.070301   \n",
-       "30    male   2.000000      5.0        2019      2020  0.210504  0.204676   \n",
-       "31    male   2.000000      5.0        2019      2020  0.699143  0.690327   \n",
+       "       sex  age_start   age_end  year_start  year_end      mean      2.5%  \\\n",
+       "0   female        0.0  0.019178        2019      2020  0.024557  0.021287   \n",
+       "1   female        0.0  0.019178        2019      2020  0.082311  0.078291   \n",
+       "2   female        0.0  0.019178        2019      2020  0.201385  0.196609   \n",
+       "3   female        0.0  0.019178        2019      2020  0.691747  0.683254   \n",
+       "..     ...        ...       ...         ...       ...       ...       ...   \n",
+       "44    male        2.0  5.000000        2019      2020  0.016175  0.013549   \n",
+       "45    male        2.0  5.000000        2019      2020  0.074177  0.070301   \n",
+       "46    male        2.0  5.000000        2019      2020  0.210504  0.204676   \n",
+       "47    male        2.0  5.000000        2019      2020  0.699143  0.690327   \n",
        "\n",
-       "       97.5%         age  age_group           risk     measure  \n",
-       "0   0.028627  1-5_months          3            sam  prevalence  \n",
-       "1   0.087508  1-5_months          3            mam  prevalence  \n",
-       "2   0.208915  1-5_months          3   mild_wasting  prevalence  \n",
-       "3   0.695940  1-5_months          3  tmrel_wasting  prevalence  \n",
-       "..       ...         ...        ...            ...         ...  \n",
-       "28  0.018823      2_to_4          6            sam  prevalence  \n",
-       "29  0.078136      2_to_4          6            mam  prevalence  \n",
-       "30  0.216590      2_to_4          6   mild_wasting  prevalence  \n",
-       "31  0.707901      2_to_4          6  tmrel_wasting  prevalence  \n",
+       "       97.5%             age  age_group           risk     measure  \n",
+       "0   0.028370  early_neonatal          1            sam  prevalence  \n",
+       "1   0.086317  early_neonatal          1            mam  prevalence  \n",
+       "2   0.206213  early_neonatal          1   mild_wasting  prevalence  \n",
+       "3   0.700573  early_neonatal          1  tmrel_wasting  prevalence  \n",
+       "..       ...             ...        ...            ...         ...  \n",
+       "44  0.018823          2_to_4          6            sam  prevalence  \n",
+       "45  0.078136          2_to_4          6            mam  prevalence  \n",
+       "46  0.216590          2_to_4          6   mild_wasting  prevalence  \n",
+       "47  0.707901          2_to_4          6  tmrel_wasting  prevalence  \n",
        "\n",
-       "[32 rows x 12 columns]"
+       "[48 rows x 12 columns]"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2365,7 +2365,7 @@
   {
    "cell_type": "code",
    "execution_count": 59,
-   "id": "4b4a88b8",
+   "id": "c81b0392",
    "metadata": {},
    "outputs": [
     {
@@ -2542,7 +2542,7 @@
   {
    "cell_type": "code",
    "execution_count": 61,
-   "id": "6c64a29b",
+   "id": "d260ab7d",
    "metadata": {},
    "outputs": [
     {
@@ -2739,7 +2739,7 @@
   {
    "cell_type": "code",
    "execution_count": 60,
-   "id": "38a1138b",
+   "id": "f3607b35",
    "metadata": {},
    "outputs": [
     {
@@ -3416,7 +3416,7 @@
   {
    "cell_type": "code",
    "execution_count": 48,
-   "id": "78237759",
+   "id": "4104ad39",
    "metadata": {},
    "outputs": [
     {
@@ -3613,7 +3613,7 @@
   {
    "cell_type": "code",
    "execution_count": 57,
-   "id": "28285523",
+   "id": "8cd69a5b",
    "metadata": {},
    "outputs": [
     {
@@ -3809,7 +3809,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 72,
    "id": "e461d57e",
    "metadata": {},
    "outputs": [
@@ -3860,7 +3860,7 @@
   {
    "cell_type": "code",
    "execution_count": 52,
-   "id": "7759598a",
+   "id": "7892e416",
    "metadata": {
     "scrolled": false
    },
@@ -3925,7 +3925,7 @@
   {
    "cell_type": "code",
    "execution_count": 53,
-   "id": "635c90f4",
+   "id": "f4b6e365",
    "metadata": {},
    "outputs": [
     {
@@ -3946,7 +3946,7 @@
   {
    "cell_type": "code",
    "execution_count": 54,
-   "id": "d8fc9edf",
+   "id": "601ce8d9",
    "metadata": {},
    "outputs": [
     {
@@ -3968,7 +3968,7 @@
   {
    "cell_type": "code",
    "execution_count": 65,
-   "id": "2f0cab37",
+   "id": "02f60332",
    "metadata": {},
    "outputs": [
     {
@@ -3989,7 +3989,7 @@
   {
    "cell_type": "code",
    "execution_count": 64,
-   "id": "fb0ea98f",
+   "id": "754b11dc",
    "metadata": {},
    "outputs": [
     {
@@ -4218,7 +4218,7 @@
   {
    "cell_type": "code",
    "execution_count": 68,
-   "id": "a843d802",
+   "id": "5104acf2",
    "metadata": {
     "scrolled": false
    },
@@ -4336,7 +4336,7 @@
   {
    "cell_type": "code",
    "execution_count": 69,
-   "id": "9482a85f",
+   "id": "bbfb58c5",
    "metadata": {},
    "outputs": [
     {
@@ -4359,7 +4359,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "934139e8",
+   "id": "d6200b59",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/nathaniel/model_validation/vivarium_output_loader.py
+++ b/nathaniel/model_validation/vivarium_output_loader.py
@@ -1,0 +1,253 @@
+import pandas as pd
+import os
+
+def locaction_paths_from_rundates(base_directory: str, locations_rundates: dict) -> dict:
+    """
+    Returns a dictionary of the form {'location': 'pathname'} from a dictionary of the form
+    {'location': 'rundate'} by constructing each pathname as
+    pathname = f'{base_directory}/{location.lower()}/{rundate}/'
+    """
+    return {location: os.path.join(base_directory, location.lower(), rundate)
+            for location, rundate in locations_rundates.items()}
+
+def load_output_by_location(locations_paths: dict, output_filename='output.hdf') -> dict:
+    """
+    Loads output.hdf file from the path for each location in the dictionary locations_paths,
+    and returns a dictionary of output DataFrames indexed by location.
+    """
+    # Read in data from different countries
+    locations_outputs = {location: pd.read_hdf(os.path.join(path, output_filename))
+                                               for location, path in locations_paths.items()}
+    return locations_outputs
+
+def merge_location_outputs(locations_outputs: dict, copy=True) -> pd.DataFrame:
+    """
+    Concatenate the output DataFrames for all locations stored in locations_outputs into a single DataFrame,
+    with a 'location' column added to specify which location each row came from.
+    """
+    if copy:
+        # Use a dictionary comprhension to avoid overwriting the input dictionary.
+        # Use DataFrame.assign to avoid overwriting the dataframes in the dictionary.
+        # Note that in the statement `output.assign(location=location)`, the first 'location' is
+        # the column name, and the second is the `location` variable, which is the
+        # value to assign to the 'location' column.
+        locations_outputs = {location: output.assign(location=location)
+                             for location, output in locations_outputs.items()}
+    else:
+        # Modify dictionary and dataframes in place
+        for location, output in locations_outputs.items():
+            output['location'] = location
+
+    # The concatenated dataframe is not intended to be modified, so we don't
+    # need to copy the sub-dataframes.
+    return pd.concat(locations_outputs.values(), copy=False, sort=False)
+
+def load_and_merge_location_outputs(locations_paths: dict, output_filename='output.hdf') -> pd.DataFrame:
+    """
+    Loads output.hdf files from the paths for the locations in the dictionary locations_paths into a single,
+    concatenated DataFrame, with a 'location' column added to specify which location each row came from.
+    """
+    locations_outputs = load_output_by_location(locations_paths, output_filename)
+    return merge_location_outputs(locations_outputs, copy=False)
+
+# # Old version, replaced with above functions on 2020-09-24:
+#
+# def load_output_by_location(locations_paths: dict, output_filename='output.hdf') -> pd.DataFrame:
+#     """
+#     Loads output.hdf files for the locations in the dictionary locations_paths into a single,
+#     concatenated DataFrame, with a 'location' column added.
+#     """
+#     # Read in data from different countries
+#     locations_outputs = {location: pd.read_hdf(os.path.join(path, output_filename))
+#                                                for location, path in locations_paths.items()}
+    
+#     for location, output in locations_outputs.items():
+#         output['location'] = location
+
+#     return pd.concat(locations_outputs.values(), copy=False, sort=False)
+
+def load_transformed_count_data(directory: str) -> dict:
+    """
+    Loads each transformed "count space" .hdf output file into a dataframe,
+    and returns a dictionary whose keys are the file names and values are
+    are the corresponding dataframes.
+    """
+    dfs = {}
+    for entry in os.scandir(directory):
+        filename_root, extension = os.path.splitext(entry.name)
+        if extension == '.hdf':
+#             print(filename_root, type(filename_root), extension, entry.path)
+            dfs[filename_root] = pd.read_hdf(entry.path)
+    return dfs
+
+def load_count_data_by_location(locations_paths: dict, subdirectory='count_data') -> dict:
+    """
+    Loads data from all locations into a dictionary of dictionaries of dataframes,
+    indexed by location. Each dictionary in the outer dictionary is
+    indexed by filename
+    
+    For each location, reads data files from a directory called f'{path}/{subdirectory}/',
+    where `path` is the path for the location specified in the `locations_paths` dictionary.
+    """
+    locations_count_data = {location: load_transformed_count_data(os.path.join(path, subdirectory))
+                        for location, path in locations_paths.items()}
+    return locations_count_data
+
+def merge_location_count_data(locations_count_data: dict, copy=True) -> dict:
+    """
+    Concatenate the count data tables from all locations into a single dictionary of dataframes
+    indexed by table name, with a column added to the begininning of each table specifying the
+    location for each row of data.
+    """
+    if copy:
+        # Use a temporary variable and a for loop instead of a dictionary comprehension
+        # so we can access the `data` variable later.
+        locations_count_data_copy = {}
+        for location, data in locations_count_data.items():
+            locations_count_data_copy[location] = {
+                table_name:
+                # Use DataFrame.reindex() to simultaneously make a copy of the dataframe and
+                # assign a new location column at the beginning.
+                table.reindex(columns=['location', *table.columns], fill_value=location)
+                for table_name, table in  data.items()
+            }
+        locations_count_data = locations_count_data_copy
+#         # Alternate version using dictionary comprehension; this version would require a different
+#         # method of iterating through the table names below, because `data` is inaccessible afterwards.
+#         locations_count_data = {
+#             location: {
+#                 table_name:
+#                 table.reindex(columns=['location', *table.columns], fill_value=location)
+#                 for table_name, table in  data.items()
+#             }
+#             for location, data in locations_count_data.items()
+#         }
+    else:
+        # Modify the dictionaries and dataframes in place
+        for location, data in locations_count_data.items():
+            for table in data.values():
+                # Insert a 'location' column at the beginning of each table
+                table.insert(0, 'location', location)
+
+    # `data` now refers to the dictionary of count_data tables for the last location
+    # encountred in the above for loop. We will use the keys stored in this dictionary
+    # to iterate through all the table names and concatenate the tables across all locations.
+    all_data = {table_name: pd.concat([locations_count_data[location][table_name]
+                                      for location in locations_count_data], copy=False, sort=False)
+                for table_name in data}
+    return all_data
+
+def load_and_merge_location_count_data(locations_paths: dict, subdirectory='count_data') -> dict:
+    locations_count_data = load_count_data_by_location(locations_paths, subdirectory)
+    return merge_location_count_data(locations_count_data, copy=False)
+
+# # Old version, replaced with above functions on 2020-09-24:
+#
+# def load_count_data_by_location(locations_paths: dict, subdirectory='count_data') -> dict:
+#     """
+#     Loads data from all locations into a dictionary of dataframes,
+#     indexed by filename, with a column added to each table specifying
+#     the location.
+    
+#     For each location, reads data files from a directory called f'{path}/{subdirectory}/',
+#     where `path` is the path for the location specified in the `locations_paths` dictionary.
+#     """
+#     location_dictionaries = []
+#     for location, path in locations_paths.items():
+#         location_dfs = load_transformed_count_data(os.path.join(path, subdirectory))
+#         for table in location_dfs.values():
+#             # Insert the 'location' column at the beginning
+#             table.insert(0, 'location', location)
+        
+#         location_dictionaries.append(location_dfs)
+        
+#     data_dict = location_dictionaries[0]
+   
+#     for location_dfs in location_dictionaries[1:]:
+#         for table_name, table in location_dfs.items():
+#             data_dict[table_name] = data_dict[table_name].append(table)
+            
+#     return data_dict
+
+##### 2020-09-24: The following functions are old and should be superceded by the above versions,
+##### which do a better job of separating concerns. Leaving them in for now because some old
+##### notebooks may use them.
+
+def load_by_location_and_rundate(base_directory: str, locations_run_dates: dict) -> pd.DataFrame:
+    """Load output.hdf files from folders namedd with the convention 'base_directory/location/rundate/output.hdf'"""
+
+    # Use dictionary to map countries to the correct path for the Vivarium output to process
+    # E.g. /share/costeffectiveness/results/sqlns/bangladesh/2019_06_21_00_09_53
+    locactions_paths = {location: f'{base_directory}/{location.lower()}/{run_date}/output.hdf'
+                       for location, run_date in locations_run_dates.items()}
+
+    # Read in data from different countries
+    locations_outputs = {location: pd.read_hdf(path) for location, path in locactions_paths.items()}
+
+    for location, output in locations_outputs.items():
+        output['location'] = location
+
+    return pd.concat(locations_outputs.values(), copy=False, sort=False)
+
+def print_location_output_shapes(all_output, locations=None):
+    """Print the shapes of outputs for each location to check whether all the same size or if some data is missing"""
+    if locations is None:
+        locations = all_output.location.unique()
+    for location in locations:
+        print(location, all_output.loc[all_output.location==location].shape)
+
+def path_for_transformed_count_data(directory, location, rundate, subdirectory='count_data'):
+    """
+    Gets the directory path for a given location and rundate.
+    
+    The returned path is 
+    f'{directory}/{location.lower()}/{rundate}/{subdirectory}'
+    """
+    return os.path.join(directory, location.lower(), rundate, subdirectory)
+
+def load_all_transformed_count_data(directory, locations_rundates):
+    """
+    Loads data from all locations into a dictionary of dataframes,
+    indexed by (location, filename).
+    
+    Assumes data files are in a directory called
+    f'{directory}/{location.lower()}/{rundate}/{subdirectory}/'
+    """
+    dfs = {}
+    for location, rundate in locations_rundates.items():
+        path = path_for_transformed_count_data(directory, location, rundate)
+        location_dfs = load_transformed_count_data(path)
+        
+        # Keys in location_dfs are filenames that describe what measures are stored in the dataframe
+        for table_name in location_dfs:
+            dfs[(location.lower(), table_name)] = location_dfs[table_name]
+            
+    return dfs
+    
+def load_transformed_count_data_and_merge_locations(directory, locations_rundates):
+    """
+    Loads data from all locations into a dictionary of dataframes,
+    indexed by filename, with a column added to each table specifying
+    the location.
+    
+    Assumes data files are in a directory called
+    f'{directory}/{location.lower()}/{rundate}/{subdirectory}/'
+    """
+    location_dictionaries = []
+    for location, rundate in locations_rundates.items():
+        path = path_for_transformed_count_data(directory, location, rundate)
+        location_dfs = load_transformed_count_data(path)
+        for table in location_dfs.values():
+            # Insert the 'location' column at the beginning
+            table.insert(0, 'location', location)
+        
+        location_dictionaries.append(location_dfs)
+        
+    data_dict = location_dictionaries[0]
+   
+    for location_dfs in location_dictionaries[1:]:
+        for table_name, table in location_dfs.items():
+            data_dict[table_name] = data_dict[table_name].append(table)
+            
+    return data_dict
+


### PR DESCRIPTION
- I copied over two .py files from https://github.com/ihmeuw/vivarium_data_analysis/tree/main/output_processing/lsff/ndbs (and made one addition to `ciff_output_processing.py`, as I'm planning to update the functions in this module)
- I fixed the issue of the missing artifact data for ENN and LNN prevalence in the wasting prevalence validation plots (at least in the final version of them -- there's still another version in the notebook that's missing the NN prevalence)