### PR TITLE
Add `marginalize` function to Vivarium output processing module

### DIFF
--- a/model_validation/vivarium_output_processing.py
+++ b/model_validation/vivarium_output_processing.py
@@ -49,6 +49,7 @@ def marginalize(df:pd.DataFrame, marginalized_cols, value_cols='value', reset_in
         which have been aggregated over.
         If reset_index == False, all the resulting columns will be placed in the DataFrame's index except for `value_cols`.
     """
+    # TOODO: Write a separate function to turn singletons into lists if necessary, instead of copying code
     marginalized_cols = marginalized_cols if isinstance(marginalized_cols, (list, pd.Index)) else [marginalized_cols]
     value_cols = value_cols if isinstance(value_cols, (list, pd.Index)) else [value_cols]
     # Move MultiIndex levels into columns to enable passing index level names as well as column names


### PR DESCRIPTION
Sequel to https://github.com/ihmeuw/vivarium_research_ciff_sam/pull/14 (merge that PR first and delete its branch to automatically switch this PR's base branch to `main`)

Copy my new `marginalize` function from the [v2.4 person-time validation notebook](https://github.com/ihmeuw/vivarium_research_ciff_sam/blob/main/model_validation/model2/2021_08_04a_ciff_sam_v2.4_person_time_vs_year.ipynb) into the `vivarium_output_processing` module.