### PR TITLE
Add helper function to process column names; improve code for `marginalize`

### DIFF
--- a/model_validation/vivarium_output_processing.py
+++ b/model_validation/vivarium_output_processing.py
@@ -62,7 +62,7 @@ def _listify_singleton_cols(colnames, df):
             raise ValueError(f"colnames must be a single column name in df or an iterable of column names")
         return colnames
 
-    return method1(colnames, df)
+    return method1(colnames, df) # Go with the most restrictive method for now
 
 def marginalize(df:pd.DataFrame, marginalized_cols, value_cols='value', reset_index=True)->pd.DataFrame:
     """Sum the values of a dataframe over the specified columns to marginalize out.

--- a/model_validation/vivarium_output_processing.py
+++ b/model_validation/vivarium_output_processing.py
@@ -97,9 +97,9 @@ def marginalize(df:pd.DataFrame, marginalized_cols, value_cols='value', reset_in
     """
     marginalized_cols = _listify_singleton_cols(marginalized_cols, df)
     value_cols = _listify_singleton_cols(value_cols, df)
-    # Move MultiIndex levels into columns to enable passing index level names as well as column names
-#     df = df.reset_index([level_name for level_name in df.index.names if level_name is not None])
-    df = df.reset_index() if df.index.nlevels > 1 else df
+    # Move Index levels into columns to enable passing index level names as well as column names to marginalize
+    if df.index.nlevels > 1 or df.index.name in marginalized_cols:
+        df = df.reset_index()
     index_cols = df.columns.difference([*marginalized_cols, *value_cols]).to_list()
     summed_data = df.groupby(index_cols, observed=True)[value_cols].sum() # observed=True needed for Categorical data
     return summed_data.reset_index() if reset_index else summed_data

--- a/model_validation/vivarium_output_processing.py
+++ b/model_validation/vivarium_output_processing.py
@@ -24,7 +24,7 @@ def _listify_singleton_cols(colnames, df):
 
     def method1(colnames, df):
         """Method 1 (doesn't depend on df): Assume that if colnames has a type that is in a whitelist of
-        allowed ierable types, then it is an iterable of column names, and otherwise it must be a single
+        allowed iterable types, then it is an iterable of column names, and otherwise it must be a single
         column name.
         """
         if not isinstance(colnames, (list, pd.Index)):

--- a/model_validation/vivarium_output_processing.py
+++ b/model_validation/vivarium_output_processing.py
@@ -50,6 +50,7 @@ def _listify_singleton_cols(colnames, df):
     def method3(colnames, df):
         """Method 3: Assume that if colnames is a string or is a hashable object that is in the dataframe's columns
         (e.g. a tuple), then it represents a single column namee. Otherwise it must be an iterable of column names.
+        (This method allows tuples of column names.)
         """
         if isinstance(colnames, collections.Hashable):
             # This line could still raise an 'unhashable type' TypeError if e.g. colnames is a tuple
@@ -59,7 +60,7 @@ def _listify_singleton_cols(colnames, df):
             elif isinstance(colnames, str): # Assume colnames is supposed to be a single column name
                 raise KeyError(f"string {colnames} not in the DataFrame")
         elif not isinstance(colnames, collections.Iterable): # assume colname is an iterable of column names
-            raise ValueError(f"colnames must be a single column name in df or an iterable of column names")
+            raise ValueError(f"{colnames} must be a single column name in df or an iterable of column names")
         return colnames
 
     return method1(colnames, df) # Go with the most restrictive method for now


### PR DESCRIPTION
Sequel to https://github.com/ihmeuw/vivarium_research_ciff_sam/pull/15 (merge https://github.com/ihmeuw/vivarium_research_ciff_sam/pull/14 and https://github.com/ihmeuw/vivarium_research_ciff_sam/pull/15 first to automatically update this PR's base branch to `main`)

The new `_listify_singleton_cols` helper function enables passing either a single column name or a list (or other iterable) of column names to other functions. I came up with three different strategies for doing this, but I'm not sure what the best solution is, so I added code for all 3 strategies and just picked the simplest one for now.