### PR TITLE
Bug fix: difference function in Vivarium output processing module

### DIFF
--- a/model_validation/vivarium_output_processing.py
+++ b/model_validation/vivarium_output_processing.py
@@ -130,11 +130,8 @@ def difference(measure:pd.DataFrame, identifier_col:str, minuend_id=None, subtra
     # Subtract DataFrames, not Series, because Series will drop the identifier column from the index
     # if there is no broadcasting. (Behavior for Series and DataFrames is different - is this a
     # feature or a bug in pandas?)
-    print(minuend.index.names)
-    print(subtrahend.index.names)
     difference = minuend[[VALUE_COLUMN]] - subtrahend[[VALUE_COLUMN]]
     difference = difference.reset_index()
-    print(difference.columns)
 
     # Add a column to specify what was subtracted from (the minuend) or what was subtracted (the subtrahend)
     colname, value = ('subtracted_from', minuend_id) if minuend_id is not None else ('subtracted_value', subtrahend_id)

--- a/model_validation/vivarium_output_processing.py
+++ b/model_validation/vivarium_output_processing.py
@@ -122,18 +122,22 @@ def difference(measure:pd.DataFrame, identifier_col:str, minuend_id=None, subtra
     # Add the identifier column to the index of the larger dataframe
     # (or default to the subtrahend dataframe if neither needs broadcasting).
     if minuend_id is None:
-        minuend.set_index(identifier_col, append=True)
+        minuend.set_index(identifier_col, append=True, inplace=True)
     else:
-        subtrahend.set_index(identifier_col, append=True)
+        print(identifier_col)
+        subtrahend.set_index(identifier_col, append=True, inplace=True)
 
     # Subtract DataFrames, not Series, because Series will drop the identifier column from the index
     # if there is no broadcasting. (Behavior for Series and DataFrames is different - is this a
     # feature or a bug in pandas?)
+    print(minuend.index.names)
+    print(subtrahend.index.names)
     difference = minuend[[VALUE_COLUMN]] - subtrahend[[VALUE_COLUMN]]
     difference = difference.reset_index()
+    print(difference.columns)
 
     # Add a column to specify what was subtracted from (the minuend) or what was subtracted (the subtrahend)
-    colname, value = 'subtracted_from', minuend_id if minuend_id is not None else 'subtracted_value', subtrahend_id
+    colname, value = ('subtracted_from', minuend_id) if minuend_id is not None else ('subtracted_value', subtrahend_id)
     difference.insert(difference.columns.get_loc(identifier_col)+1, colname, value)
 
     return difference

--- a/model_validation/vivarium_output_processing.py
+++ b/model_validation/vivarium_output_processing.py
@@ -124,7 +124,6 @@ def difference(measure:pd.DataFrame, identifier_col:str, minuend_id=None, subtra
     if minuend_id is None:
         minuend.set_index(identifier_col, append=True, inplace=True)
     else:
-        print(identifier_col)
         subtrahend.set_index(identifier_col, append=True, inplace=True)
 
     # Subtract DataFrames, not Series, because Series will drop the identifier column from the index


### PR DESCRIPTION
Sequel to https://github.com/ihmeuw/vivarium_research_ciff_sam/pull/14  (merge that PR first and delete its branch to automatically switch this PR's base branch to `main`)

Fixes two bugs in the `difference` function in `vivarium_output_processing.py`:

- Save the result after adding the identifier column to the index
- Add missing parentheses for tuple unpacking in the ternary conditional operator