### PR TITLE
Add functionality to `ratio` function in Vivarium output processing module

### DIFF
--- a/model_validation/vivarium_output_processing.py
+++ b/model_validation/vivarium_output_processing.py
@@ -169,7 +169,7 @@ def ratio(
     multiplier=1,
     numerator_broadcast=None,
     denominator_broadcast=None,
-    value_cols=VALUE_COLUMN,
+    value_col=VALUE_COLUMN,
     measure_col=MEASURE_COLUMN,
     dropna=False,
     record_inputs=None,
@@ -187,7 +187,7 @@ def ratio(
     denominator : DataFrame
         The denominator data for the ratio or rate.
 
-    strata : list of column names present in the numerator and denominator
+    strata : list of column names present in the numerator and denominator (also accepts a single column name)
         The stratification variables for the ratio or rate.
 
     multiplier : int or float, default 1
@@ -215,9 +215,30 @@ def ratio(
         at once, or pass 'measure' to compute a ratio or rate for multiple measures at
         once (like deaths, ylls, and ylds).
 
+    denominator_broadcast : list of column names present in the denominator, or None
+        Additional columns in the numerator by which to broadcast.
+
+    value_col : single column name (a singleton list is also accepted), default VALUE_COLUMN
+        The column where the values in the numerator and denominator dataframes are stored.
+
+    measure_col: single column name (a singleton list is also accepted), default MEASURE_COLUMN
+        The column indicating the type of measure stored in the numerator and denominator dataframes.
+        Not used if `record_inputs` is False.
+
     dropna : boolean, default False
          Whether to drop rows with NaN values in the result, namely
          if division by 0 occurs because of an empty stratum in the denominator.
+
+    record_inputs : boolean or None, default None
+        Whether to record the multiplier and the numeraor's and denominator's measures in the output.
+        If None, defaults to the value of `reset_index` to facilitate performing further operations with
+        the ratio if reset_index == False.
+
+    reset_index : boolean, default True
+        Whether to move index levels back into the dataframe's columns after computing the ratio.
+        If reset_index==False and record_inputs==False, the only column of the returned dataframe
+        will be `value_col`, which can facilitate performing further operations on the ratio (e.g.
+        multiplying by a constant or combining with another dataframe that has the same index).
 
      Returns
      -------
@@ -255,8 +276,8 @@ def ratio(
     # Ensure strata is an iterable of column names so it can be concatenated with broadcast columns
     strata = _listify_singleton_cols(strata, denominator)
     # Stratify numerator and denominator with broadcast columns included
-    numerator = stratify(numerator, [*strata, *numerator_broadcast], value_cols=value_cols, reset_index=False)
-    denominator = stratify(denominator, [*strata, *denominator_broadcast], value_cols=value_cols, reset_index=False)
+    numerator = stratify(numerator, [*strata, *numerator_broadcast], value_cols=value_col, reset_index=False)
+    denominator = stratify(denominator, [*strata, *denominator_broadcast], value_cols=value_col, reset_index=False)
 
     # Compute the ratio
     ratio = (numerator / denominator) * multiplier

--- a/model_validation/vivarium_output_processing.py
+++ b/model_validation/vivarium_output_processing.py
@@ -170,6 +170,7 @@ def ratio(
     numerator_broadcast=None,
     denominator_broadcast=None,
     value_cols=VALUE_COLUMN,
+    measure_col=MEASURE_COLUMN,
     dropna=False,
     record_inputs=None,
     reset_index=True,
@@ -239,8 +240,8 @@ def ratio(
     if record_inputs:
         # Really I think the 'measure' column should always have a unique value, but
         # currently that is not the case for transition counts...
-        numerator_measure = '|'.join(numerator[MEASURE_COLUMN].unique())
-        denominator_measure = '|'.join(denominator[MEASURE_COLUMN].unique())
+        numerator_measure = '|'.join(numerator[measure_col].unique())
+        denominator_measure = '|'.join(denominator[measure_col].unique())
 
     # Ensure strata is a list so it can be concatenated with broadcast columns
     strata = _listify_singleton_cols(strata, denominator)
@@ -255,8 +256,8 @@ def ratio(
         ratio.dropna(inplace=True)
 
     if record_inputs:
-        ratio[f'numerator_{MEASURE_COLUMN}'] = numerator_measure
-        ratio[f'denominator_{MEASURE_COLUMN}'] = denominator_measure
+        ratio[f'numerator_{measure_col}'] = numerator_measure
+        ratio[f'denominator_{measure_col}'] = denominator_measure
         ratio['multiplier'] = multiplier
 
     if reset_index:

--- a/model_validation/vivarium_output_processing.py
+++ b/model_validation/vivarium_output_processing.py
@@ -167,6 +167,7 @@ def ratio(
     strata: list,
     multiplier=1,
     numerator_broadcast=None,
+    denominator_broadcast=None,
     dropna=False,
 )-> pd.DataFrame:
     """
@@ -225,9 +226,14 @@ def ratio(
     else:
         numerator_broadcast = _listify_singleton_cols(numerator_broadcast, numerator)
 
+    if denominator_broadcast is None:
+        denominator_broadcast = []
+    else:
+        denominator_broadcast = _listify_singleton_cols(denominator_broadcast, denominator)
+
     strata = _listify_singleton_cols(strata, denominator)
     numerator = stratify(numerator, strata+numerator_broadcast, reset_index=False)
-    denominator = stratify(denominator, strata, reset_index=False)
+    denominator = stratify(denominator, strata+denominator_broadcast, reset_index=False)
 
 #     numerator = numerator.groupby(strata+index_cols+numerator_broadcast)[VALUE_COLUMN].sum()
 #     denominator = denominator.groupby(strata+index_cols)[VALUE_COLUMN].sum()

--- a/model_validation/vivarium_output_processing.py
+++ b/model_validation/vivarium_output_processing.py
@@ -240,8 +240,8 @@ def ratio(
     if record_inputs:
         # Really I think the 'measure' column should always have a unique value, but
         # currently that is not the case for transition counts...
-        numerator_measure = '|'.join([measure for measure in numerator[MEASURE_COLUMN].unique()])
-        denominator_measure = '|'.join([measure for measure in denominator[MEASURE_COLUMN].unique()])
+        numerator_measure = '|'.join(numerator[MEASURE_COLUMN].unique())
+        denominator_measure = '|'.join(denominator[MEASURE_COLUMN].unique())
 
     strata = _listify_singleton_cols(strata, denominator)
     numerator = stratify(numerator, strata+numerator_broadcast, reset_index=False)

--- a/model_validation/vivarium_output_processing.py
+++ b/model_validation/vivarium_output_processing.py
@@ -222,9 +222,15 @@ def ratio(
 
     if numerator_broadcast is None:
         numerator_broadcast = []
+    else:
+        numerator_broadcast = _listify_singleton_cols(numerator_broadcast, numerator)
 
-    numerator = numerator.groupby(strata+index_cols+numerator_broadcast)[VALUE_COLUMN].sum()
-    denominator = denominator.groupby(strata+index_cols)[VALUE_COLUMN].sum()
+    strata = _listify_singleton_cols(strata, denominator)
+    numerator = stratify(numerator, strata+numerator_broadcast, reset_index=False)
+    denominator = stratify(denominator, strata, reset_index=False)
+
+#     numerator = numerator.groupby(strata+index_cols+numerator_broadcast)[VALUE_COLUMN].sum()
+#     denominator = denominator.groupby(strata+index_cols)[VALUE_COLUMN].sum()
 
     ratio = (numerator / denominator) * multiplier
 

--- a/model_validation/vivarium_output_processing.py
+++ b/model_validation/vivarium_output_processing.py
@@ -224,7 +224,7 @@ def ratio(
      ratio : DataFrame
          The ratio or rate data = numerator / denominator.
     """
-    # Ensure that numerator_broadcast and denominator_broadcast are lists
+    # Ensure that numerator_broadcast and denominator_broadcast are iterables of column names
     if numerator_broadcast is None:
         numerator_broadcast = []
     else:
@@ -252,11 +252,11 @@ def ratio(
         numerator_measure = '|'.join(numerator[measure_col].unique())
         denominator_measure = '|'.join(denominator[measure_col].unique())
 
-    # Ensure strata is a list so it can be concatenated with broadcast columns
+    # Ensure strata is an iterable of column names so it can be concatenated with broadcast columns
     strata = _listify_singleton_cols(strata, denominator)
     # Stratify numerator and denominator with broadcast columns included
-    numerator = stratify(numerator, strata+numerator_broadcast, value_cols=value_cols, reset_index=False)
-    denominator = stratify(denominator, strata+denominator_broadcast, value_cols=value_cols, reset_index=False)
+    numerator = stratify(numerator, [*strata, *numerator_broadcast], value_cols=value_cols, reset_index=False)
+    denominator = stratify(denominator, [*strata, *denominator_broadcast], value_cols=value_cols, reset_index=False)
 
     # Compute the ratio
     ratio = (numerator / denominator) * multiplier

--- a/model_validation/vivarium_output_processing.py
+++ b/model_validation/vivarium_output_processing.py
@@ -165,10 +165,11 @@ def stratify(df: pd.DataFrame, strata, value_cols=VALUE_COLUMN, reset_index=True
 def ratio(
     numerator: pd.DataFrame,
     denominator: pd.DataFrame,
-    strata: list,
+    strata,
     multiplier=1,
     numerator_broadcast=None,
     denominator_broadcast=None,
+    value_cols=VALUE_COLUMN,
     dropna=False,
     record_inputs=None,
     reset_index=True,
@@ -241,9 +242,11 @@ def ratio(
         numerator_measure = '|'.join(numerator[MEASURE_COLUMN].unique())
         denominator_measure = '|'.join(denominator[MEASURE_COLUMN].unique())
 
+    # Ensure strata is a list so it can be concatenated with broadcast columns
     strata = _listify_singleton_cols(strata, denominator)
-    numerator = stratify(numerator, strata+numerator_broadcast, reset_index=False)
-    denominator = stratify(denominator, strata+denominator_broadcast, reset_index=False)
+    # Stratify numerator and denominator with broadcast columns included
+    numerator = stratify(numerator, strata+numerator_broadcast, value_cols=value_cols, reset_index=False)
+    denominator = stratify(denominator, strata+denominator_broadcast, value_cols=value_cols, reset_index=False)
 
     ratio = (numerator / denominator) * multiplier
 

--- a/model_validation/vivarium_output_processing.py
+++ b/model_validation/vivarium_output_processing.py
@@ -169,6 +169,7 @@ def ratio(
     numerator_broadcast=None,
     denominator_broadcast=None,
     dropna=False,
+    reset_index=True,
 )-> pd.DataFrame:
     """
     Compute a ratio or rate by dividing the numerator by the denominator.
@@ -244,7 +245,10 @@ def ratio(
     if dropna:
         ratio.dropna(inplace=True)
 
-    return ratio.reset_index()
+    if reset_index:
+        ratio.reset_index(inplace=True)
+
+    return ratio
 
 def difference(measure:pd.DataFrame, identifier_col:str, minuend_id=None, subtrahend_id=None)->pd.DataFrame:
     """

--- a/model_validation/vivarium_output_processing.py
+++ b/model_validation/vivarium_output_processing.py
@@ -222,8 +222,6 @@ def ratio(
      ratio : DataFrame
          The ratio or rate data = numerator / denominator.
     """
-    index_cols = INDEX_COLUMNS
-
     if numerator_broadcast is None:
         numerator_broadcast = []
     else:
@@ -246,9 +244,6 @@ def ratio(
     strata = _listify_singleton_cols(strata, denominator)
     numerator = stratify(numerator, strata+numerator_broadcast, reset_index=False)
     denominator = stratify(denominator, strata+denominator_broadcast, reset_index=False)
-
-#     numerator = numerator.groupby(strata+index_cols+numerator_broadcast)[VALUE_COLUMN].sum()
-#     denominator = denominator.groupby(strata+index_cols)[VALUE_COLUMN].sum()
 
     ratio = (numerator / denominator) * multiplier
 

--- a/model_validation/vivarium_output_processing.py
+++ b/model_validation/vivarium_output_processing.py
@@ -224,6 +224,7 @@ def ratio(
      ratio : DataFrame
          The ratio or rate data = numerator / denominator.
     """
+    # Ensure that numerator_broadcast and denominator_broadcast are lists
     if numerator_broadcast is None:
         numerator_broadcast = []
     else:
@@ -234,6 +235,14 @@ def ratio(
     else:
         denominator_broadcast = _listify_singleton_cols(denominator_broadcast, denominator)
 
+    # Avoid potential confusion by requiring common stratification columns to go in strata.
+    if len(set(numerator_broadcast) & set(denominator_broadcast)) > 0:
+        raise ValueError(
+            "`numerator_broadcast` and `denominator_broadcast` must be disjoint lists of column names."
+            " Any column to include in both the numerator and denominator should go in `strata`."
+        )
+
+    # Default behavior is to record inputs only if index is reset
     if record_inputs is None:
         record_inputs = reset_index
 
@@ -249,6 +258,7 @@ def ratio(
     numerator = stratify(numerator, strata+numerator_broadcast, value_cols=value_cols, reset_index=False)
     denominator = stratify(denominator, strata+denominator_broadcast, value_cols=value_cols, reset_index=False)
 
+    # Compute the ratio
     ratio = (numerator / denominator) * multiplier
 
     # If dropna is True, drop rows where we divided by 0


### PR DESCRIPTION
Add several parameters to the `ratio` function to allow more flexible usage and to keep track of what it computes.