### PR TITLE
Model 3.1 V&V - Wasting prevalence ratios and effect size uncertainty

### DIFF
--- a/model_validation/model3/2021_09_09a_ciff_sam_v3.1_vv.ipynb
+++ b/model_validation/model3/2021_09_09a_ciff_sam_v3.1_vv.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "c0fa8f76",
+   "id": "10f64b06",
    "metadata": {},
    "outputs": [
     {
@@ -12,7 +12,7 @@
      "text": [
       "/ihme/homes/ndbs/vivarium_research_ciff_sam/model_validation/model3\n",
       "ndbs\n",
-      "Thu Sep  9 16:55:37 PDT 2021\n"
+      "Fri Sep 10 15:08:07 PDT 2021\n"
      ]
     }
    ],
@@ -22,6 +22,7 @@
     "import pandas as pd\n",
     "pd.set_option('display.max_rows', 8)\n",
     "\n",
+    "from scipy import stats\n",
     "import collections\n",
     "\n",
     "import warnings\n",
@@ -53,7 +54,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "f361cbef",
+   "id": "4bad2c41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,8 +63,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e894852",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
-   "id": "0a33140e",
+   "id": "0a622d9b",
    "metadata": {},
    "source": [
     "# Validation and Verification Criteria from SQLNS documentation\n",
@@ -83,7 +92,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f5931591",
+   "id": "d20ede7d",
    "metadata": {},
    "source": [
     "# Load output from model 3.1 SQLNS and compute total person time"
@@ -92,7 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "9bd1d41f",
+   "id": "5c7fb1f3",
    "metadata": {},
    "outputs": [
     {
@@ -123,7 +132,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9cdc88b6",
+   "id": "c2dad490",
    "metadata": {},
    "source": [
     "# 1. Check SQ-LNS coverage as a function of time\n",
@@ -136,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "941efa4f",
+   "id": "0f6618eb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,7 +157,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "419aff89",
+   "id": "91c14d7e",
    "metadata": {},
    "outputs": [
     {
@@ -335,7 +344,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "af612733",
+   "id": "8e62af9c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -346,7 +355,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "ff3cfb97",
+   "id": "3371da30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -356,7 +365,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "beef35b0",
+   "id": "3f1a9059",
    "metadata": {},
    "source": [
     "## Check that coverage under 6 months is always 0\n",
@@ -367,7 +376,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "3edf0e78",
+   "id": "1d5ad69c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -378,7 +387,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "95486710",
+   "id": "884fafac",
    "metadata": {},
    "outputs": [
     {
@@ -577,7 +586,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "46cdb2b7",
+   "id": "e71f234c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -586,7 +595,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3fa4aa7c",
+   "id": "ad636e6f",
    "metadata": {},
    "source": [
     "## Check that for age > 6mo, coverage goes from 0% in 2022 to 90% in 2023\n",
@@ -597,7 +606,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "20410253",
+   "id": "b52cbff2",
    "metadata": {},
    "outputs": [
     {
@@ -785,7 +794,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "68072895",
+   "id": "fefe78d2",
    "metadata": {},
    "outputs": [
     {
@@ -987,7 +996,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "7bda67a1",
+   "id": "cd40f3d2",
    "metadata": {},
    "outputs": [
     {
@@ -1188,7 +1197,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "4878f518",
+   "id": "18c8e26a",
    "metadata": {},
    "outputs": [
     {
@@ -1388,18 +1397,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8fdc0bc9",
+   "id": "5bbb6927",
    "metadata": {},
    "source": [
     "# 2. Verify prevalence of stunting in supplemented vs non-supplemented group\n",
     "\n",
-    "See [SQ-LNS Vivarium Modeling Strategy](https://vivarium-research.readthedocs.io/en/latest/intervention_models/lipid_based_nutrient_supplements/index.html#vivarium-modeling-strategy)"
+    "See [SQ-LNS Vivarium Modeling Strategy](https://vivarium-research.readthedocs.io/en/latest/intervention_models/lipid_based_nutrient_supplements/index.html#vivarium-modeling-strategy)\n",
+    "\n",
+    "Target prevalence ratios Pr(cat_i | SQLNS) / Pr(cat_i | no SQLNS):\n",
+    "- cat1 (severe stunting): 0.85 (95% CI 0.74 to 0.98)\n",
+    "- cat2 (moderate stunting): 0.93 (95% CI 0.88 to 0.98)\n",
+    "- cat3 (mild stunting): Ratio depends on the category prevalences for the stratum -- should be greater than 1\n",
+    "- cat4 (TMREL): 1.0 (no uncertainty)\n",
+    "\n",
+    "We'll compute the prevalence ratios for each (year, sex, age, draw) combination for which both SQLNS-covered person-time and SQLNS-uncovered person-time is nonzero. There are 288 such combinations: (1 intervention scenario) x (4 years > 2022) x (2 sexes) x (3 age groups > 6mo) x (12 draws).\n",
+    " \n",
+    "First define some functions that will be useful later."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "07020da3",
+   "id": "14628a42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def normal_dist_from_mean_lower_upper(mean, lower, upper, scale_factor=1, quantile_ranks=(0.025,0.975)):\n",
+    "    \"\"\"Returns a frozen normal distribution with the specified mean, such that\n",
+    "    (lower, upper) are approximately equal to the quantiles with ranks\n",
+    "    (quantile_ranks[0], quantile_ranks[1]).\n",
+    "    The `scale_factor` parameter allows scaling the resulting distribution by a specified factor.\n",
+    "    \"\"\"\n",
+    "    # quantiles of the standard normal distribution with specified quantile_ranks\n",
+    "    stdnorm_quantiles = stats.norm.ppf(quantile_ranks)\n",
+    "    scale = (upper - lower) / (stdnorm_quantiles[1] - stdnorm_quantiles[0])\n",
+    "    # Frozen normal distribution\n",
+    "    return stats.norm(loc=mean, scale=scale*scale_factor)\n",
+    "\n",
+    "def plot_pdf(dist, label, ax=None):\n",
+    "    \"\"\"Plot the probability density function of a scipy.stats frozen distribution.\"\"\"\n",
+    "    if ax is None: ax = plt.gca()\n",
+    "    x = np.linspace(dist.ppf(0.01), dist.ppf(0.99), 100)\n",
+    "    ax.plot(x, dist.pdf(x), lw=2, alpha=0.8, label=label)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "35eb9c6e",
    "metadata": {},
    "outputs": [
     {
@@ -1574,7 +1619,7 @@
        "[11520 rows x 9 columns]"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1585,18 +1630,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9572c9bd",
+   "id": "f9544183",
    "metadata": {},
    "source": [
     "## Calculate the prevalence ratios\n",
     "\n",
-    "Should we stratify by year, or not???"
+    "Should we stratify by year, or not??? Omitting year stratification decreases the variance in the computed prevalence ratios. Not sure what that means or whether it's desirable for verification purposes."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "6a52a304",
+   "execution_count": 17,
+   "id": "a7e7f1b7",
    "metadata": {},
    "outputs": [
     {
@@ -1803,36 +1848,522 @@
        "[1152 rows x 10 columns]"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "stunting_prevalence_ratio = csr.get_sqlns_stunting_prevalence_ratio(data, stratify_by_year=True)\n",
+    "stunting_prevalence_ratio = csr.get_sqlns_risk_prevalence_ratio(data, 'stunting', stratify_by_year=True)\n",
     "stunting_prevalence_ratio"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b6c6bb3a",
+   "id": "7e4eb87d",
+   "metadata": {},
+   "source": [
+    "## How much do the prevalence ratios vary across draws within each stratum?\n",
+    "\n",
+    "Each row of the below table describes the distribution across draws for a single stratum."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "374c11c9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>count</th>\n",
+       "      <th>mean</th>\n",
+       "      <th>std</th>\n",
+       "      <th>min</th>\n",
+       "      <th>2.5%</th>\n",
+       "      <th>50%</th>\n",
+       "      <th>97.5%</th>\n",
+       "      <th>max</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>age</th>\n",
+       "      <th>denominator_measure</th>\n",
+       "      <th>multiplier</th>\n",
+       "      <th>numerator_measure</th>\n",
+       "      <th>scenario</th>\n",
+       "      <th>sex</th>\n",
+       "      <th>stunting_state</th>\n",
+       "      <th>year</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"4\" valign=\"top\">12_to_23_months</th>\n",
+       "      <th rowspan=\"4\" valign=\"top\">stunting_prevalence_among_sqlns_uncovered</th>\n",
+       "      <th rowspan=\"4\" valign=\"top\">1</th>\n",
+       "      <th rowspan=\"4\" valign=\"top\">stunting_prevalence_among_sqlns_covered</th>\n",
+       "      <th rowspan=\"4\" valign=\"top\">treatment_and_prevention</th>\n",
+       "      <th rowspan=\"4\" valign=\"top\">female</th>\n",
+       "      <th rowspan=\"4\" valign=\"top\">cat1</th>\n",
+       "      <th>2023</th>\n",
+       "      <td>12.0</td>\n",
+       "      <td>0.862358</td>\n",
+       "      <td>0.024040</td>\n",
+       "      <td>0.826349</td>\n",
+       "      <td>0.830223</td>\n",
+       "      <td>0.863956</td>\n",
+       "      <td>0.905536</td>\n",
+       "      <td>0.912309</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2024</th>\n",
+       "      <td>12.0</td>\n",
+       "      <td>0.856474</td>\n",
+       "      <td>0.017161</td>\n",
+       "      <td>0.832787</td>\n",
+       "      <td>0.833038</td>\n",
+       "      <td>0.854986</td>\n",
+       "      <td>0.883806</td>\n",
+       "      <td>0.885757</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025</th>\n",
+       "      <td>12.0</td>\n",
+       "      <td>0.848152</td>\n",
+       "      <td>0.023137</td>\n",
+       "      <td>0.803698</td>\n",
+       "      <td>0.811021</td>\n",
+       "      <td>0.844641</td>\n",
+       "      <td>0.883677</td>\n",
+       "      <td>0.885221</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2026</th>\n",
+       "      <td>12.0</td>\n",
+       "      <td>0.855110</td>\n",
+       "      <td>0.016623</td>\n",
+       "      <td>0.828633</td>\n",
+       "      <td>0.830405</td>\n",
+       "      <td>0.858041</td>\n",
+       "      <td>0.876353</td>\n",
+       "      <td>0.876701</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"4\" valign=\"top\">6-11_months</th>\n",
+       "      <th rowspan=\"4\" valign=\"top\">stunting_prevalence_among_sqlns_uncovered</th>\n",
+       "      <th rowspan=\"4\" valign=\"top\">1</th>\n",
+       "      <th rowspan=\"4\" valign=\"top\">stunting_prevalence_among_sqlns_covered</th>\n",
+       "      <th rowspan=\"4\" valign=\"top\">treatment_and_prevention</th>\n",
+       "      <th rowspan=\"4\" valign=\"top\">male</th>\n",
+       "      <th rowspan=\"4\" valign=\"top\">cat1</th>\n",
+       "      <th>2023</th>\n",
+       "      <td>12.0</td>\n",
+       "      <td>0.847798</td>\n",
+       "      <td>0.024739</td>\n",
+       "      <td>0.817404</td>\n",
+       "      <td>0.818768</td>\n",
+       "      <td>0.844040</td>\n",
+       "      <td>0.882872</td>\n",
+       "      <td>0.883326</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2024</th>\n",
+       "      <td>12.0</td>\n",
+       "      <td>0.862814</td>\n",
+       "      <td>0.020187</td>\n",
+       "      <td>0.817167</td>\n",
+       "      <td>0.821987</td>\n",
+       "      <td>0.867452</td>\n",
+       "      <td>0.885623</td>\n",
+       "      <td>0.887231</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025</th>\n",
+       "      <td>12.0</td>\n",
+       "      <td>0.849090</td>\n",
+       "      <td>0.031713</td>\n",
+       "      <td>0.804130</td>\n",
+       "      <td>0.807565</td>\n",
+       "      <td>0.851789</td>\n",
+       "      <td>0.901413</td>\n",
+       "      <td>0.904316</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2026</th>\n",
+       "      <td>12.0</td>\n",
+       "      <td>0.851276</td>\n",
+       "      <td>0.022198</td>\n",
+       "      <td>0.810389</td>\n",
+       "      <td>0.815989</td>\n",
+       "      <td>0.845832</td>\n",
+       "      <td>0.884990</td>\n",
+       "      <td>0.886281</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>24 rows × 8 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                                                                                                                                  count  \\\n",
+       "age             denominator_measure                       multiplier numerator_measure                       scenario                 sex    stunting_state year          \n",
+       "12_to_23_months stunting_prevalence_among_sqlns_uncovered 1          stunting_prevalence_among_sqlns_covered treatment_and_prevention female cat1           2023   12.0   \n",
+       "                                                                                                                                                            2024   12.0   \n",
+       "                                                                                                                                                            2025   12.0   \n",
+       "                                                                                                                                                            2026   12.0   \n",
+       "...                                                                                                                                                                 ...   \n",
+       "6-11_months     stunting_prevalence_among_sqlns_uncovered 1          stunting_prevalence_among_sqlns_covered treatment_and_prevention male   cat1           2023   12.0   \n",
+       "                                                                                                                                                            2024   12.0   \n",
+       "                                                                                                                                                            2025   12.0   \n",
+       "                                                                                                                                                            2026   12.0   \n",
+       "\n",
+       "                                                                                                                                                                      mean  \\\n",
+       "age             denominator_measure                       multiplier numerator_measure                       scenario                 sex    stunting_state year             \n",
+       "12_to_23_months stunting_prevalence_among_sqlns_uncovered 1          stunting_prevalence_among_sqlns_covered treatment_and_prevention female cat1           2023  0.862358   \n",
+       "                                                                                                                                                            2024  0.856474   \n",
+       "                                                                                                                                                            2025  0.848152   \n",
+       "                                                                                                                                                            2026  0.855110   \n",
+       "...                                                                                                                                                                    ...   \n",
+       "6-11_months     stunting_prevalence_among_sqlns_uncovered 1          stunting_prevalence_among_sqlns_covered treatment_and_prevention male   cat1           2023  0.847798   \n",
+       "                                                                                                                                                            2024  0.862814   \n",
+       "                                                                                                                                                            2025  0.849090   \n",
+       "                                                                                                                                                            2026  0.851276   \n",
+       "\n",
+       "                                                                                                                                                                       std  \\\n",
+       "age             denominator_measure                       multiplier numerator_measure                       scenario                 sex    stunting_state year             \n",
+       "12_to_23_months stunting_prevalence_among_sqlns_uncovered 1          stunting_prevalence_among_sqlns_covered treatment_and_prevention female cat1           2023  0.024040   \n",
+       "                                                                                                                                                            2024  0.017161   \n",
+       "                                                                                                                                                            2025  0.023137   \n",
+       "                                                                                                                                                            2026  0.016623   \n",
+       "...                                                                                                                                                                    ...   \n",
+       "6-11_months     stunting_prevalence_among_sqlns_uncovered 1          stunting_prevalence_among_sqlns_covered treatment_and_prevention male   cat1           2023  0.024739   \n",
+       "                                                                                                                                                            2024  0.020187   \n",
+       "                                                                                                                                                            2025  0.031713   \n",
+       "                                                                                                                                                            2026  0.022198   \n",
+       "\n",
+       "                                                                                                                                                                       min  \\\n",
+       "age             denominator_measure                       multiplier numerator_measure                       scenario                 sex    stunting_state year             \n",
+       "12_to_23_months stunting_prevalence_among_sqlns_uncovered 1          stunting_prevalence_among_sqlns_covered treatment_and_prevention female cat1           2023  0.826349   \n",
+       "                                                                                                                                                            2024  0.832787   \n",
+       "                                                                                                                                                            2025  0.803698   \n",
+       "                                                                                                                                                            2026  0.828633   \n",
+       "...                                                                                                                                                                    ...   \n",
+       "6-11_months     stunting_prevalence_among_sqlns_uncovered 1          stunting_prevalence_among_sqlns_covered treatment_and_prevention male   cat1           2023  0.817404   \n",
+       "                                                                                                                                                            2024  0.817167   \n",
+       "                                                                                                                                                            2025  0.804130   \n",
+       "                                                                                                                                                            2026  0.810389   \n",
+       "\n",
+       "                                                                                                                                                                      2.5%  \\\n",
+       "age             denominator_measure                       multiplier numerator_measure                       scenario                 sex    stunting_state year             \n",
+       "12_to_23_months stunting_prevalence_among_sqlns_uncovered 1          stunting_prevalence_among_sqlns_covered treatment_and_prevention female cat1           2023  0.830223   \n",
+       "                                                                                                                                                            2024  0.833038   \n",
+       "                                                                                                                                                            2025  0.811021   \n",
+       "                                                                                                                                                            2026  0.830405   \n",
+       "...                                                                                                                                                                    ...   \n",
+       "6-11_months     stunting_prevalence_among_sqlns_uncovered 1          stunting_prevalence_among_sqlns_covered treatment_and_prevention male   cat1           2023  0.818768   \n",
+       "                                                                                                                                                            2024  0.821987   \n",
+       "                                                                                                                                                            2025  0.807565   \n",
+       "                                                                                                                                                            2026  0.815989   \n",
+       "\n",
+       "                                                                                                                                                                       50%  \\\n",
+       "age             denominator_measure                       multiplier numerator_measure                       scenario                 sex    stunting_state year             \n",
+       "12_to_23_months stunting_prevalence_among_sqlns_uncovered 1          stunting_prevalence_among_sqlns_covered treatment_and_prevention female cat1           2023  0.863956   \n",
+       "                                                                                                                                                            2024  0.854986   \n",
+       "                                                                                                                                                            2025  0.844641   \n",
+       "                                                                                                                                                            2026  0.858041   \n",
+       "...                                                                                                                                                                    ...   \n",
+       "6-11_months     stunting_prevalence_among_sqlns_uncovered 1          stunting_prevalence_among_sqlns_covered treatment_and_prevention male   cat1           2023  0.844040   \n",
+       "                                                                                                                                                            2024  0.867452   \n",
+       "                                                                                                                                                            2025  0.851789   \n",
+       "                                                                                                                                                            2026  0.845832   \n",
+       "\n",
+       "                                                                                                                                                                     97.5%  \\\n",
+       "age             denominator_measure                       multiplier numerator_measure                       scenario                 sex    stunting_state year             \n",
+       "12_to_23_months stunting_prevalence_among_sqlns_uncovered 1          stunting_prevalence_among_sqlns_covered treatment_and_prevention female cat1           2023  0.905536   \n",
+       "                                                                                                                                                            2024  0.883806   \n",
+       "                                                                                                                                                            2025  0.883677   \n",
+       "                                                                                                                                                            2026  0.876353   \n",
+       "...                                                                                                                                                                    ...   \n",
+       "6-11_months     stunting_prevalence_among_sqlns_uncovered 1          stunting_prevalence_among_sqlns_covered treatment_and_prevention male   cat1           2023  0.882872   \n",
+       "                                                                                                                                                            2024  0.885623   \n",
+       "                                                                                                                                                            2025  0.901413   \n",
+       "                                                                                                                                                            2026  0.884990   \n",
+       "\n",
+       "                                                                                                                                                                       max  \n",
+       "age             denominator_measure                       multiplier numerator_measure                       scenario                 sex    stunting_state year            \n",
+       "12_to_23_months stunting_prevalence_among_sqlns_uncovered 1          stunting_prevalence_among_sqlns_covered treatment_and_prevention female cat1           2023  0.912309  \n",
+       "                                                                                                                                                            2024  0.885757  \n",
+       "                                                                                                                                                            2025  0.885221  \n",
+       "                                                                                                                                                            2026  0.876701  \n",
+       "...                                                                                                                                                                    ...  \n",
+       "6-11_months     stunting_prevalence_among_sqlns_uncovered 1          stunting_prevalence_among_sqlns_covered treatment_and_prevention male   cat1           2023  0.883326  \n",
+       "                                                                                                                                                            2024  0.887231  \n",
+       "                                                                                                                                                            2025  0.904316  \n",
+       "                                                                                                                                                            2026  0.886281  \n",
+       "\n",
+       "[24 rows x 8 columns]"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# How much do the prevalence ratios vary across draws within each stratum?\n",
+    "# Looks like from about .80-.83 to .88-.91 from the 8 visible rows\n",
+    "vop.describe(stunting_prevalence_ratio.query(\"stunting_state=='cat1'\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc8c180e",
+   "metadata": {},
+   "source": [
+    "## How much do the prevalence ratios vary across strata within a single draw?\n",
+    "\n",
+    "The variation within each draw is similar to the variation between draws shown above.\n",
+    "\n",
+    "The means for each draw all look suspiciously close to 0.85. I would expect the means for the 12 draws to look like 12 values drawn from the normal distribution with mean 0.85 and central 95% interval (0.74, 0.98) -- see sample values below. Instead it seems like maybe within each draw, values are being drawn from this distribution, wihch is different from my interpretation of parameter uncertainty. Am I thinking about this the right way?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "744e4db4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.79720684, 0.87724187, 0.7837265 , 0.78070813, 0.87892382,\n",
+       "       0.83945878, 0.906437  , 0.86465482, 0.82687448, 0.93150207,\n",
+       "       0.84682143, 0.79310103])"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cat1_dist = normal_dist_from_mean_lower_upper(0.85, 0.74, 0.98)\n",
+    "cat1_dist.rvs(12)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "496697c9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.75153404, 0.84894095, 0.8865375 , 0.75254683, 0.74650949,\n",
+       "       0.85630741, 0.91323477, 0.91277555, 0.94138705, 0.80748848,\n",
+       "       0.75060315, 0.85028009])"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cat1_dist.rvs(12)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "910396d7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "count    24.000000\n",
+       "mean      0.847264\n",
+       "std       0.018603\n",
+       "min       0.795176\n",
+       "25%       0.840170\n",
+       "50%       0.850236\n",
+       "75%       0.857313\n",
+       "max       0.892203\n",
+       "Name: value, dtype: float64"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# How much do the prevalence ratios vary across strata within a single draw?\n",
+    "# from about .80 to .89 for draw 29, similar to the variation between draws above\n",
+    "stunting_prevalence_ratio.query(\"stunting_state=='cat1' and input_draw==29\").value.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "b682fa6c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "count    24.000000\n",
+       "mean      0.850664\n",
+       "std       0.019861\n",
+       "min       0.817167\n",
+       "25%       0.841831\n",
+       "50%       0.849781\n",
+       "75%       0.853955\n",
+       "max       0.904316\n",
+       "Name: value, dtype: float64"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stunting_prevalence_ratio.query(\"stunting_state=='cat1' and input_draw==223\").value.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "657bbfa6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "count    24.000000\n",
+       "mean      0.838565\n",
+       "std       0.019476\n",
+       "min       0.796221\n",
+       "25%       0.828939\n",
+       "50%       0.843691\n",
+       "75%       0.850775\n",
+       "max       0.868862\n",
+       "Name: value, dtype: float64"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stunting_prevalence_ratio.query(\"stunting_state=='cat1' and input_draw==232\").value.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "ea480444",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "count    24.000000\n",
+       "mean      0.857703\n",
+       "std       0.018747\n",
+       "min       0.816619\n",
+       "25%       0.849407\n",
+       "50%       0.853134\n",
+       "75%       0.874370\n",
+       "max       0.889523\n",
+       "Name: value, dtype: float64"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stunting_prevalence_ratio.query(\"stunting_state=='cat1' and input_draw==357\").value.describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2134c58",
    "metadata": {},
    "source": [
     "## Verify that prevalence ratios match the targets for each stunting category\n",
     "\n",
     "Targets:\n",
-    " - cat1 (severe stunting): 0.85 (95% CI 0.74 to 0.98)\n",
-    " - cat2 (moderate stunting): 0.93 (95% CI 0.88 to 0.98)\n",
-    " - cat3 (mild stunting): Ratio depends on the category prevalences for the stratum -- should be greater than 1\n",
-    " - cat4 (TMREL): 1.0 (no uncertainty)\n",
+    "- cat1 (severe stunting): 0.85 (95% CI 0.74 to 0.98)\n",
+    "- cat2 (moderate stunting): 0.93 (95% CI 0.88 to 0.98)\n",
+    "- cat3 (mild stunting): Ratio depends on the category prevalences for the stratum -- should be greater than 1\n",
+    "- cat4 (TMREL): 1.0 (no uncertainty)\n",
     " \n",
-    "The sim is matching the targets quite well."
+    "The sim means are matching the targets quite well, but there is less variation than I would expect from our specified uncertainty. This could be because we only have 12 draws, or because the ratios for different strata are not independent within the same draw, or both. Or it could be related to my comment above about the parameter uncertainty behaving differently from my expectations. Or it could be none of these. I'm not sure how to correctly stratify our resuls to verify that the uncertainty matches our specification."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "9571adae",
+   "execution_count": 25,
+   "id": "aa98d481",
    "metadata": {},
    "outputs": [
     {
@@ -1849,7 +2380,7 @@
        "Name: value, dtype: float64"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1860,8 +2391,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "id": "45349d3c",
+   "execution_count": 26,
+   "id": "a5097973",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY4AAAEWCAYAAABxMXBSAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAABJ4UlEQVR4nO2dd7iU1bX/P99DV3o70gSUjiAC9hKwl1iDGiOJLXqNGk2uKeYm98afMVdTLNFriom9YYktGjuCXQGlo/QqTaQr5cD6/bH3wHCYmfOexsw5rM/zvM/Mu+vab1u7ri0zw3Ecx3GSUpRvARzHcZyahSsOx3Ecp1y44nAcx3HKhSsOx3Ecp1y44nAcx3HKhSsOx3Ecp1y44nDyiqTzJb1a1WFrKpKul/RwvuWoSiTtLWmdpDoViHu/pBtz+K+TtE/lJHTKiyuOKkbSEZLek7Ra0peS3pV0YL7lqgiSukgySXWrKz0ze8TMjk8Svzxhnfwhaa6kY1PnZjbfzBqb2ZaqziumO7sMeYZIWljVee/OuOKoQiQ1BV4A7gRaAh2A/wds3MVyVMmH3snM7nx9d+eyZ6MiLakaj5n5UUUHMBhYVUaYi4FpwErgFaBzdP8L8MdSYZ8D/jP+bw/8E1gOzAGuTgt3PfAU8DCwBvg+0Ay4B1gMLAJuBOpkkekgYGyMuxS4NbrPBwxYF49DY14Pp8XtEsPUjeejgN8A7wJrgVeB1jnSuxB4Jy09Ay4HZgCrgLsARb/yhK0D3AJ8Ea/XVelyZrgGc4FfAFPjvbkPaBj9hgALgZ8DS4CHCJWu64BZwArgCaBlDP8ScFWp9CcAZ8X/fwIWxOs9Djiy1L1Mv76HAO/F8k0AhqT5Zb3W0f+ItLgLgAujewPgj/F+LAX+CjTKcl0ujOnfFst5I7AvMDKefwE8AjSP4R8CtgJfx3v8M3Z+RtoDzwNfAjOBS3O8L/fH+/piLOOHwL6lnoFu8f/J8f6tJTzzPwH2jLJsZftz1z5eg9uBz+NxO9AgLd2fEd6dzwnvU3o+9xPe138D64FjgVOAT+I9XQBcn+EduSj6rSQ8twcCE+P9+b98f7/K9a3LtwC16QCaxpfpAeAkoEUp/9Pji9IbqAv8Cngv+h0VH6rUh69FfODbEz5S44D/AeoD+wCzgRNi2OuBzcAZMWwj4Bngb/HFaQt8BPxHFrnfB74b/zcGDon/d3jh0/IqS3HMAnpEOUYBN+dI70J2VgYvAM2BvQmK8sQKhL2c8BHpGK/l66XzLnUN5gKTgU6E1uK7wI3RbwhQAvyO8MFpBFwDfBDTbxCv9WMx/PeAd9PS7kP4ODSI58OBVoRn4FqCMmpY+voSWqwrCB/EIuC4eN4mwbXuTPiAngfUi/kNiH63ET7cLYEmwL+Am7Jclwtj2X8Y5W0EdIuyNADaAG8Bt5e6lsfmeEbeAv4MNAQGxPt2dJb8749lPijm/wgwotQzkPqgLyYq4XjPB6bdv4Wl0r0h3r+2sQzvAb+JfifGe9IX2INQISutOFYDh8f70jDm0S+e9yco5DNKlf+vMezxwAbg2Zh/B2AZ8I18f8MSf+vyLUBtOwhK4X5CDbUkvqDF0e8l4JK0sEXAV/ElF6EGeFT0uxQYGf8fDMwvlc8vgPvi/+uBt9L8igndY43S3M4D3swi81uELrXWpdx3eOHT8ipLcfwqzf8K4OUc6V3IzsrgiLTzJ4DrKhB2JGmKklArLEtxXJ52fjIwK/4fAmwiftyj2zTgmLTzdgTlXZfwMV7P9tbkb4F7czwzK4H9S19fQgvnoVJhXwEuSHCtfwE8kyEvRdnSa+2HAnOyyHYhpZ69DGHOAD4pdS0zKg6CYt4CNEnzvwm4P0va9wP/KHVfPi31DKQ+6POB/wCalkpjCDsrjlnAyWnnJwBz4/97SVOkBEVZWnE8WMY1uR24rVT5O6T5rwDOTTv/J/CjXGkW0uFjHFWMmU0zswvNrCOwH6HFcHv07gz8SdIqSasITXURHigDRhA+8ADfIdSuUvHap+LFuP9FUBApFqT970yoZS5OC/83Qu0mE5cQaq2fShoj6ZsVKvx2lqT9/4rQiqmu+NnCtmfHa5L+PxvpYebFNFIsN7MNaeedgWfSru80wgex2MzWErpWvh3Dnsf2e4mkn0iaFidQrCJ0K7bOIE9n4OxS9/0IgpJKka38nQgfx9K0IdSix6Wl+XJ0z8YO105SsaQRkhZJWkOokWeSPxPtgS/jNUoxj1DrzkbS5+FbBMUyT9JoSYeWIce8UjK0T/Mr69kpfU0OlvSmpOWSVhNavKWvydK0/19nOC/ve5I3XHFUI2b2KaF2sl90WkCoBTdPOxqZ2XvR/zFgmKTOhFbGP9PizSkVr4mZnZyeXdr/BYQWR+u08E3NrG8WOWeY2XkExfI74ClJe5ZKM8V6wocnxV7JrsZOMlY3iwndSCk6JYiTHmZvQv92itKyLwBOKnVPGprZouj/GHBe/Hg1BN4EkHQkof/8HEJXZnNCt4cyyLOA0OJIz2NPM7s5QVkWEMYiSvMF4SPVNy3NZmaW66NVuuz/G936mVlTQtebcoRP53OgpaQmaW57E8YkKoWZjTGz0wnP8bOEFmg2eT4nKOZ0GVL3O8mzUzrNRwm9C53MrBmhWyrTPa0VuOKoQiT1knStpI7xvBOhtvlBDPJX4BeS+kb/ZpLOTsU3s08IL/Y/gFfMbFX0+ghYK+nnkhpJqiNpv2zTfM1sMWGg9BZJTSUVSdpX0jeyyD1cUhsz20roi4cwmLg8/qbPkx8PHBXn5jcjdIkkJVN61cUTwDWSOkhqTuj2KYsrJXWU1BL4JfB4jrB/BX4blTyS2kg6Pc3/34QP0w3A4/HaQujGKiFci7qS/ocwNpaJh4FTJZ0Q73nDOLW0Y5bw6TwCHCvpHEl1JbWSNCDK8XfgNklto+wdJJ2QIM0UTQiDzKsldQB+Wsp/KVnusZktIIwn3BTL05/Q4q3U2hVJ9eM6n2ZmtpkwSJ265kuBVvF5TfEY8Kt431oTxg9TMjwBXCSpt6Q9gP9OIEITQktqg6SDCD0GtRZXHFXLWkJL4UNJ6wkKYzJhABQze4ZQox8Rm/iTCYPo6TxK6I9/NOVgYf77NwkDiXPYrlyakZ3vEQbSU7OEnmLHLo50TgSmSFpHmPHzbTP72sy+IvTPvxu7NQ4xs9cIH9SJhAH7F8q4JtvIlF7SuBXg7wTlOZEw2+XfhA92rrUEj8Y4swndPFkXnhGu0/PAq5LWEu71wSlPM9sIPE2pe0kYo3gZmE7oHtlAlm60+JE9ndAtuTyG+ykJ3lszm0/otrmW0CU6Htg/ev+cMEnjg/gcvg70LCvNNP4fMJDQUnqRUM50biJ8lFdJ+kmG+OcR+v0/J0zi+LWZvV6O/LPxXWBuLNPlwPmwreX/GDA7ytSecG/HEp6PScDH0Q0zewm4g9BKnMn2il+uafVXADfEZ+F/2N7aqZWkZvA4Tq1G0knAX82scxb/ucD3q+gD5tQiJPUmVPIamFlJvuUpBLzF4dRKYpfeybGbpgPwa0Lt1nHKRNKZkhpIakHoJfiXK43tuOJwaisidKmsJHRVTSN0IThOEv6DsLZiFqF78wf5Faew8K4qx3Ecp1x4i8NxHMcpF7XSYFnr1q2tS5cuGf3Wr1/PnnvuuWsFqmZqY5mgdpbLy1RzqI3lylWmcePGfWFmuRaCbqNWKo4uXbowduzYjH6jRo1iyJAhu1agaqY2lglqZ7m8TDWH2liuXGWSNC+jRwa8q8pxHMcpF644HMdxnHLhisNxHMcpF7VyjMNxdhc2b97MwoUL2bBhQ9mBq4lmzZoxbdq0vOVfXdTGcjVr1ow5c+bQsWNH6tWrV+F0ylQckg4HxpvZeknDCTZq/mRmiQdSHMepHhYuXEiTJk3o0qULUn6Msa5du5YmTZqUHbCGURvLtWbNGjZt2sTChQvp2rVrhdNJ0lX1F+ArSfsTDKbNAh6scI6O41QZGzZsoFWrVnlTGk7NQhKtWrWqdAs1ieIoiZsMnU7YF/cugglhx3EKAFcaTnmoiuclyRjHWkm/IGzWcpSkIsLuco7jOM5uSJIWx7kEO/SXmNkSws5Yf6hWqRzHqTE0bdqUa6+9dtv5H//4R66//vpt57fffjsPPhh6t7/88kuOO+44unfvznHHHcfKlSszpvmzn/2Mvn370rt3b66++urUvtwMGTKEnj17MmDAAAYMGMCyZcvKlO+mm26iW7du9OzZk1deeSVjmDlz5nDwwQfTrVs3zj33XDZt2rTN74knnqBPnz707duX73xn+/5MJ554Is2bN+eb38y80/JNN91EvXr1eOihh3Zwf+SRR+jfvz/9+vXjsMMOY8KECQBs2rSJo446ipKSihvhHTVq1DZ5Nm7cyLHHHsuAAQN4/PFce5KVnyQbwiwxs1vN7O14Pt/MfIzDcSrApEWr6XLdixmPmkqDBg14+umn+eKLL3byKykp4d577932wb355ps55phjmDFjBscccww337zzLrjvvfce7777LhMnTmTy5MmMGTOG0aNHb/N/5JFHGD9+POPHj6dt27Y5ZZs6dSojRoxgypQpvPzyy1xxxRVs2bLzXl4///nP+fGPf8zMmTNp0aIF99xzDwAzZszgpptu4t1332XKlCncfvvt2+L89Kc/3UkppHjooYd4+eWXmTZtGrfccguvv759m5euXbsyevRoJk2axH//939z2WWXAVC/fn2OOeaYKvvIf/LJJwCMHz+ec889t0rSTFGm4pB0lqQZklZLWiNpbdxhy3Ech7p163LZZZdx22237eQ3cuRIBg4cSN26oVf8ueee44ILLgDgggsu4Nlnn90pjiQ2bNjApk2b2LhxI5s3b6a4uLhCsj333HN8+9vfpkGDBnTt2pVu3brx0Ucf7RDGzBg5ciTDhg3bSa6///3vXHnllbRo0QJgB0V1zDHHZJx19frrr/Pggw/y73//m27duvHqq6/y61//elvL4rDDDtuW3iGHHMLChQu3xT3jjDN45JFHdkpz7ty59OrVi/PPP5/evXszbNgwvvrqKwBefvllevXqxcCBA3n66bAZ47Jlyxg+fDhjxoxhwIABzJo1q0LXLxtJxjh+D5xqZrVrQrPj1Db+lnFL+crzH6PLDHLllVfSv39/fvazn+3g/u677zJo0KBt50uXLqVdu7CD8V577cXSpUt3SuvQQw9l6NChtGvXDjPjqquuonfv3tv8L7roIurUqcO3vvUtfvWrX+Uc7F20aBGHHLJ9h+KOHTuyaNGiHcKsWLGC5s2bb1Nu6WGmT58OwOGHH86WLVu4/vrrOfHEE3Nei2OPPZZjjz1223nbtm159913M4a95557OOmk7btH77fffowZMyZj2M8++4x77rmHww8/nIsvvpg///nPXHXVVVx66aWMHDlyWzdbKs9//OMf/PGPf+SFFxLv7pyYJGMcS11pOI6Ti6ZNm/K9732PO+64Ywf3xYsX06ZNZoOrkjJ+9GfOnMm0adNYuHAhixYtYuTIkbz99ttA6KaaNGkSb7/9Nm+//XbWrqKqoqSkhBkzZjBq1Cgee+wxLr30UlatWlUlab/55pvcc889/O53v9vmVqdOHerXr8/atWt3Ct+pUycOP/xwAIYPH84777zDp59+SteuXenevTuSGD58eJXIVhZJWhxjJT0OPEvaZu1mVnqDesdx8kmClkF18qMf/YiBAwdy0UUXbXNr1KjRDmsGiouLWbx4Me3atWPx4sUZxyieeeYZDjnkEBo3bgzASSedxPvvv8+RRx5Jhw4dAGjSpAnf+c53+Oijj/je976XVaYOHTqwYMGCbecLFy7clkaKVq1asWrVKkpKSqhbt+4OYTp27MjBBx9MvXr16Nq1Kz169GDGjBkceOCBFbhC25k4cSLf//73eemll2jVqtUOfhs3bqRhw4Y7xSmtZPM5DTtJi6Mp8BVwPHBqPDJPI3AcZ7elZcuWnHPOOdsGlgF69+7NzJkzt52fdtppPPDAAwA88MADnH766Tuls/feezN69GhKSkrYvHkzo0ePpnfv3pSUlGwbgN+8eTMvvPAC++23HxCUzS9+8Yud0jrttNMYMWIEGzduZM6cOcyYMYODDjpohzCSGDp0KE899dROcp1xxhmMGjUKgC+++ILp06ezzz77VPQSATB//nzOOussHnroIXr06LGD34oVK2jdunVGcyDz58/n/fffB+DRRx/liCOOoFevXsydO3fbGMZjjz1WKdmSkmRW1UUZjot3hXCO49Qsrr322h1mV5100km89dZb286vu+46XnvtNbp3787rr7/OddddB8DYsWP5/ve/D8CwYcPYd9996devH/vvvz/7778/p556Khs3buSEE06gf//+DBgwgA4dOnDppZcCMGvWLJo2bbqTPH379uWcc86hT58+nHjiidx1113UqVMHgJNPPpnPP/8cgN/97nfceuutdOvWjRUrVnDJJZcAcMIJJ9CqVSv69OnD0KFD+cMf/rCthXDkkUdy9tln88Ybb9CxY8esU31Lc8MNN7BixQquuOIKBgwYwODBg7f5vfnmm5xyyikZ4/Xs2ZO77rqL3r17s3LlSn7wgx/QsGFD7r77bk455RQGDhxY5iyzKsPMch6EdRvPEDZuXwb8E+hYVrx8HoMGDbJsvPnmm1n9aiq1sUxmtbNcdzz8rHX++QsZj4owderUKpaw/KxZsyan/xlnnGHTp0+vVhnOP/98W7ZsWZWmWVa5qoMzzzzTPvvss53c58yZY3379q10+qkyZXpugLGW8BubpKvqPuB5oH08/hXdHMdxyuTmm29m8eLF1ZrHww8/nHUQvqawadMmzjjjjJ26rwqRJIqjjZndZ2Yl8bgfqNl3yHGcXUbPnj056qij8i1GwVO/fv2sA/1dunRh8uTJu1ii7CRRHCskDZdUJx7DgRXVLZjjOMmwaI7DcZJQFc9LEsVxMXAOsARYDAwDLsoZw3GcXULDhg1ZsWKFKw8nEWbGihUrMk73LQ9lruOwsGHTaZXKxXGcaqFjx44sXLiQ5cuX502GDRs2VPpDVIjUxnJt2LCB5s2b07Fjx0qlk1VxSPqZmf1e0p3ATtUZM7u6Ujk7jlNpUgvT8smoUaM44IAD8ipDdVAby1VVZcrV4kiZGRlb6Vwcx3GcWkNWxWFm/4p/vzKzJ9P9JJ1drVI5juM4BUuSwfGd1/FndnMcx3F2A3KNcZwEnAx0kJRu8rIpUPEtqhzHcZwaTa4Wx+eE8Y0NwLi043nghKoWRFInSW9KmippiqRrovv1khZJGh+Pk6s6b8dxHCc5ucY4JgATJD1qZpt3gSwlwLVm9rGkJsA4Sa9Fv9vM7I+7QAbHcRynDJLsx9FF0k1AH2DbpGYzq5xt4VKY2WLCAkPMbK2kaUCH3LEcx3GcXU1SI4d/IbQIhgIPAg9Xp1CSugAHAB9Gp6skTZR0r6QW1Zm34ziOkxuVZapA0jgzGyRpkpn1S3erFoGkxsBo4Ldm9rSkYuALwiLE3wDtLMN+IJIuAy4DKC4uHjRixIiM6a9bt27bzmK1hdpYJqiZ5Zq0aHVO/+JGsPTrzH79OjSrBomqn5p4n5JQG8uVq0xDhw4dZ2aDM3qWIklX1UZJRcAMSVcBi4BquZqS6hH2+3jE4ta0ZrY0zf/vQMad183sbuBugMGDB9uQIUMy5jFq1Ciy+dVUamOZoGaW68LrXszpf22/Em6ZlPm1m3v+kGqQqPqpifcpCbWxXFVVpiRdVdcAewBXA4OA7wIXVDrnUihsoHsPMM3Mbk1zb5cW7EygcGwLO47j7IYkMXI4Jv5dR/VaxT2coJQmSRof3f4LOE/SAEJX1VzgP6pRBsdxHKcMylQcknoAPwU6p4c3s6OrUhAzewdQBq9/V2U+juM4TuVIMsbxJPBX4O/AluoVx3Ecxyl0kiiOEjP7S7VL4jiO49QIkgyO/0vSFZLaSWqZOqpdMsdxHKcgSdLiSM2g+mmamwFVunLccRzHqRkkmVWV3+3FHMdxnIIil1n1o81spKSzMvmnFug5juM4uxe5WhzfAEYCp2bwM8AVh+M4zm5ILrPqv46/1bnoz3Ecx6lhlDmrSlIrSXdI+ljSOEl/ktRqVwjnOI7jFB5JpuOOAJYD3wKGxf+PV6dQjuM4TuGSZDpuOzP7Tdr5jZLOrS6BHMdxnMImSYvjVUnfllQUj3OAV6pbMMdxHKcwyTUddy1h9pSAH7F9178igqXcn+SI2wJoD3wNzDWzrVUkr+M4jpNncs2qalKehCQ1A64EzgPqE8ZCGgLFkj4A/mxmb1ZCVsdxHKcASDLGgaT+QBd2NKteeh3HU4T9yI80s1Wl4g8CvitpHzO7pzICO47jOPklyX4c9wL9gSlAqstppwWAZnZctjTMbBwwruJiOo7jOIVCkhbHIWbWJ2mCkh4GRgNvm9mnFZbMcRzHKUiSzKp6X1JixUHYN7wdcKek2ZL+KemaionnOI7jFBpJWhwPEpTHEmAjYZaVmVn/TIHN7E1JbwEHAkOBy4G+wJ+qRmTHcRwnnyRRHPcA3wUmsX2MIyuS3gD2BN4H3gYONLNllRHScRzHKRySKI7lZvZ8OdKcCAwC9gNWA6skvW9mX1dEQMdxHKewSKI4PpH0KPAvQlcVkH0/DjP7MYCkJsCFwH3AXkCDygrrOI7j5J8kiqMRQWEcn+aWdT8OSVcBRxJaHXOBewldVo7jOE4tIMnWseXdj6MhcCswzsxKKiSV4ziOU7Ak2Y+jo6RnJC2Lxz8ldcwW3sz+aGYfAi0l7Z06qlRqx3EcJ28kWcdxH/A8wWhhe8JYx33ZAks6VdIMYA5hIeBc4KVKS+o4juMUBEkURxszu8/MSuJxP9AmR/gbgUOA6WbWFTgG+KDyojqO4ziFQBLFsULScEl14jEcWJEj/GYzWwEUSSqKFnEHV4m0juM4Tt5JojguBs4BlgCLCdvH5howXyWpMfAW8IikPwHry8pEUidJb0qaKmlKykyJpJaSXpM0I/62SCCz4ziOU02UqTjMbJ6ZnWZmbcysrZmdYWbzc0Q5HfgK+DHwMjALODWBLCXAtdGg4iHAldFG1nXAG2bWHXgjnjuO4zh5IsmsqgckNU87bxFNrWcKWwd4wcy2xvGQB8zsjth1lRMzW2xmH8f/a4FpQAeCInogBnsAOKOstBzHcZzqI0lXVf/0jZnMbCVwQKaAZrYF2Bp3A6wwkrrEPD4Eis1scfRaAhRXJm3HcRyncsjMcgeQJgBDosJAUktgtJn1yxL+OcJH/zXSxjbM7OpEAoXxkdHAb83saUmrzKx5mv9KM9tpnEPSZcBlAMXFxYNGjBiRMf1169bRuHHjJKLUGGpjmaBmlmvSotU5/YsbwdIsVtv6dahUfStv1MT7lITaWK5cZRo6dOg4M0s0kSmJyZFbCGbVn4znZwO/zRH+abKYIykLSfWAfwKPpNnCWiqpnZktltQOyGhp18zuBu4GGDx4sA0ZMiRjHqNGjSKbX02lNpYJama5LrzuxZz+1/Yr4ZZJmV+7uecPqQaJqp+aeJ+SUBvLVVVlSmJy5EFJY4Gjo9NZZjY1R/gHsvnlQpIIJtynmdmtaV7PAxcAN8ff5yqSvuM4jlM1JGlxEBVFVmUBIGkSwfhhtjQybvyUxuHEfT8kjY9u/0VQGE9IugSYR5ga7DiO4+SJRIojId+Mv1fG34fi73ByKJQUZvYOYXfBTBxTOdEcx3GcqqLKFIeZzQOQdJyZpc+6+rmkj/H1F47jOLWCnNNxJdVN+99Y0uA4q6qMaDo87eSwsvJxHMdxag5ZP+iSLiTMaJou6STClrC/AyZIOi9HmpcAf5Y0V9Jc4M8EsyWO4zhOLSBXV9W1QE+gCTABOMDMZkkqJqzReCxTJDMbB+yfWgRoZrkntjuO4zg1ilyKY4uZfQF8IWmdmc0CMLOlYeZsblxhOI7j1E5yKY75km4itDg+lXQLYWHfsQQruY7jOM5uSK5B6+HAGmAhcBrwPvALgq2oC6tdMsdxHKcgydriMLM1wE1pTk/Fo1xIGgx8bmafl188x3Ecp9DINatqcNxY6eG4ydJrklZJGiMpo3XcLPwQeFHS45UX13Ecx8k3ucY4/gz8GmgOvAf82MyOk3RM9Ds0SQZmdgGApCaVE9VxHMcpBHKNcdQzs5fM7DHAzOwpwp83gIbZIikwXNL/xPO9JR0UN2dyHMdxaji5FMcGScdLOhswSWcASPoGsCVHvFRrJLVIcC1wVxXI6jiO4xQAubqqLgd+D2wFTgB+IOl+YBFxw6QsHGxmAyV9AmHHQEn1q0hex3EcJ8/kmlU1gaAwUlwTj7LYHPceNwBJbQjKx3Ecx6kFlGXksJekY+J2runuJ+aIdgfwDNBW0m+Bd4D/rbSkjuM4TkGQazru1YTd9n4ITJZ0epp3VkVgZo8APyOsAVkMnGFmT2YL7ziO49Qsco1xXAoMMrN1kroAT0nqYmZ/IvuGS0Sz68tIM4IoqZ6Zba4imR3HcZw8kktxFJnZOgAzmytpCEF5dCaH4gA+BjoBK2O45sASSUuBS6P1XMdxHKeGkmuMY6mkAamTqES+CbQG+uWI9xpwspm1NrNWwEnAC8AVhKm6juM4Tg0ml+L4HrAk3cHMSszse8BROeIdYmavpMV5FTjUzD4AGlRGWMdxHCf/5JqOuzCH37s50lws6efAiHh+LqH1Ugeflus4jlPjqY69wL8DdASejcfe0a0OcE415Oc4juPsQnINjleIuGvgD7N4z6zq/BzHcZxdS07FEbuXXjezoUkTjCvFfwb0Jc0YopkdXVEhHcdxnMIhp+Iwsy2StkpqVo49xB8BHifMwLocuABYXjkxHaf20+W6F7P6zb35lF0oiePkJklX1TpgkqTXgPUpRzO7Okv4VmZ2j6RrzGw0MFrSmCqQ1XEcxykAkiiOp+ORlNQK8cWSTgE+B1qWVzDHcRynMClTcZjZA5IaAXub2WcJ0rxRUjPgWuBOoCnw48qJ6TiO4xQKZU7HlXQqMB54OZ4PkPR8tvBm9oKZrTazyWY21MwGmVnW8Gn53CtpmaTJaW7XS1okaXw8Tk5UKsdxHKfaSLKO43rgIGAVgJmNB/apBlnuBzKZa7/NzAbE49/VkK/jOI5TDpIojs0ZZlRV+QpwM3sL+LKq03Ucx3GqliSKY4qk7wB1JHWXdCfwXjXLlc5VkibGrqwWuzBfx3EcJwMys9wBpD2AXwLHR6dXgBvNbEOiDMIGUEvM7MMEYbsAL5jZfvG8GPiCsA3tb4B2ZnZxlriXEfdCLy4uHjRixIhMwVi3bh2NGzfO6FdTqY1lgsIt16RFSZc07UxxI1j6dfnj9evQrMJ5VjeFep8qS20sV64yDR06dJyZDU6SThLFMdDMPi6/iNvi/y/BDHtdMzupjLBdSFMcSf1KM3jwYBs7dmxGv1GjRjFkyJCyBa9B1MYyQeGWK9dCvbK4tl8Jt0wqv6WfQl4AWKj3qbLUxnLlKpOkxIojyRN8i6S9gKeAx81sclkR0jGz/ypP+HQktTOzxfH0TKBceTuO4zhVT5ljHNFO1VCC2ZC/SZok6VfZwkv6jaS6aedNJd1XVj6SHgPeB3pKWijpEuD3Mb+JUQZfD+I4jpNnErWZzWwJcIekNwkGDP8HuDFHmh9KuggoBv6PsBCwrDzOy+B8TxL5HMdxnF1HmYpDUm/CZkzDCAPVjxNWhWfEzH4h6XXgQ8K+40eZmZtTdxzHqSUkaXHcS9jN73gz+7yswJKOAu4AbiAMit8p6ZIkcR3HcZzCJ4mtqkMl1Qd6SGoJfGZmm3NE+SNwtplNBZB0FjAS6FUVAjuO4zj5JUlX1TeAB4G5gIBOki6IK70zcaiZbUmdmNnTkkZXhbCO4zhO/kmycvxWQjfVN8zsKOAE4LYc4feV9EbKWKGk/sAPKi+q4ziOUwgkURz10s2pm9l0oF6O8H8HfkHcl8PMJgLfroyQjuM4TuGQZHB8rKR/AA/H8/OBzMuyA3uY2UeS0t1KKiif4ziOU2AkURw/AK4EUlvFvg38OUf4LyTtS7AvhaRhwOIc4R3HcZwaRJJZVRsJ4xy3JkzzSuBuoJekRcAcYHiFJXQcx3EKivJbWysDM5sNHCtpT6DIzNZWdR6O4zhO/kgyOF4uJF0jqSnwFXCbpI8lHV9WPMdxHKdmkGTP8X7lTPNiM1tD2L+jFfBd4OYKyOY4juMUIElaHH+W9JGkKyQl2U0mNZ3qZOBBM5uS5uY4juPUcJKYVT+SMAW3EzBO0qOSjssRZZykVwmK4xVJTaiGPcodx3Gc/JDUrPqMuAfHWIIBwwMUFmr8l5k9XSr4JcAAYLaZfSWpFXBRFcrsOI7j5JEktqr6Ez78pwCvAaea2ceS2hM2XtpBcZjZVuDjtPMVwIqqFNpxHMfJH0laHHcC/yC0Lr5OOZrZ57l2AnQcx3FqJ0kGx58xs4fSlYakawDM7KFqk8xxHMcpSJIoju9lcLuwiuVwHMdxaghZu6oknQd8B+gq6fk0rybAl0kzkDQt/r3LzP6vQlI6juM4BUOuMY73CMYJWwO3pLmvBSYmzcDMeseZVYdUSELHcRynoMiqOMxsHjAPODRpYpLqAK+b2dBSaa0AXqyokI7jOE7hkHWMQ9I78XetpDVpx1pJazLFiVvGbk24wtxxHMepgeRqcRwRf5uUM811wCRJrwHr09K7OnsUx3Ecp6aQZAHgvsBCM9soaQjQn2CDalWWKE9TalGg4ziVo8t1uXt65958yi6SxHGSLQD8JzBYUjfCBk3PAY8SbFHthJk9UHXiOY7jOIVGEsWx1cxKJJ0J3Glmd0r6JFtgSd2Bm4A+QMOUu5ntU2lpHcdxnLyTZAHg5rim4wLghehWL0f4+4C/ACXAUOBB4OHKCOk4juMUDkkUx0WEKbm/NbM5kroCuUyNNDKzNwCZ2Twzu55gINFxHMepBZTZVWVmU4Gr087nAL/LEWWjpCJghqSrgEVA47LykXQv8E1gmZntF91aAo8DXYC5wDlmtrKstBzHcZzqI8nWsYdLek3SdEmzJc2RNDtHlGuAPQjKZhAwnNDNVRb3AyeWcrsOeMPMugNvxHPHcRwnjyQZHL8H+DEwDthSVmAzGwMgaauZJd7AyczektSllPPpwJD4/wFgFPDzpGk6juM4VY/MLHcA6UMzOzhxgtKhBGXT2Mz2lrQ/8B9mdkWCuF2AF9K6qlaZWfP4X8DK1HmGuJcBlwEUFxcPGjFiRMY81q1bR+PGZfac1ShqY5mgcMs1adHqCsctbgRLvy47XHnp1yF/xhoK9T5VltpYrlxlGjp06DgzG5wknSQtjjcl/YGwqG9jytHMPs4S/nbgBOD5GG6CpKOSCJMLMzNJWbWcmd1NWGfC4MGDbciQIRnDjRo1imx+NZXaWCYo3HJdWMZivFxc26+EWyYl2rG5XMw9f0iVp5mUQr1PlaU2lquqypTkCU61NtI1kQFHZ4tgZgtCA2EbZXZxZWGppHZmtlhSO2BZBdNxHMdxqogks6qGlhWmFAskHQaYpHqEwfJpZcTJxvOEgfWb4+9zFUzHcRzHqSKS2KoqBv4XaG9mJ0nqAxxqZvdkiXI58CegA2Eq7qvAlQnyeYwwEN5a0kLg1wSF8YSkSwgm3s8ps0SOU0nKsgvlOLs7Sbqq7iesBv9lPJ9OWFuRTXGYmZ1fXkHM7LwsXseUNy3HcRyn+kiycry1mT0BbAUwsxJyj1l8IOlJSSep1ECH4ziOU/NJ0uJYH7d+NQBJhwC55iP2AI4FLgbulPQEcL+ZTa+ssI7jZCZX95qbXHeqmiSK4z8Jg9T7SnoXaAMMyxbYwsKQ14DXJA0lGDi8QtIE4Doze7/yYjuO4zj5Ismsqo8lfQPoCQj4zMw2ZwsfWyfDge8CS4EfEhTPAOBJoGvlxXYcx3HyRVbFIemsLF49JGFm2Xb5e59gPfcMM1uY5j5W0l8rKKfjOI5TIORqcZwaf9sChwEj4/lQ4D2ybw/b07LYMTGzXFZ1HcdxnBpAVsWRMlAo6VWgj5ktjuftCFN0d0DS34E7zGxSBr89gXOBjWb2SNWI7jiO4+SDJIPjnVJKI7IU2DtDuLuA/5bUD5gMLCdsHdsdaArcC7jScBzHqeEkURxvSHoFeCyenwu8XjqQmY0HzpHUmGDXqh3wNTDNzD6rGnEdx3GcfJNkVtVVks4EUhZu7zazZ3KEX0fYN8NxHMephSSy7xwVRVZl4TiO4+w+JDE54jiO4zjbqLIdZSQ9ZGbflXSNmf2pqtJ1HKdylGXt102SOOWlzBaHpFMlJWmZDJLUHrhYUgtJLdOPyovqOI7jFAJJWhznArdL+idwr5l9miXcX4E3gH2AcQTzJCksujuO4zg1nDJbEmY2HDgAmAXcL+l9SZdJalIq3B1m1pugXPYxs65physNx3GcWkKiwXEzWwM8BYwgrM84E/hY0g8zhP2BpP0lXRWP/lUqseM4jpNXkoxxnC7pGcLajHrAQWZ2ErA/cG2G8FcTVoi3jccjmRSM4ziOUzNJMsZxFnCbmb2V7mhmX8W9wEvzfeBgM1sPIOl3BIu5d1ZWWMcpXIymfEUzraMpX9OYr9lDG6jPZhqwmXpx08xea7bwraI6bKYuG6nLRurxlTVkLXuwlkasssasoxE7DhE6TmGRRHEsKa00JP3OzH5uZm9kCC923Fp2C/4WOLWAIrbSXivopGV01HLa8SV7aQVttJpWWkPdnDsqB4pXGcV1c78Om6jHl9aEpdaCxdaSJdaShdaG+daWpbTAfPmVk2eSKI7jgJ+Xcjspg1uK+4APY/cWwBnAPRWSznHyRBFb6arFdNciumkR3YoWsbeW5VQOX9GQldaYtbYHa9mD9TRgo9VnE3XZHF+1oU23MmqdqEcJ9SmhgTbTOLZQmuhrWmgtjdjIXvqSvfQl+zNrhzw2UY95VszMrR2Yae2Zbh2Zb21dmTi7lFwbOf0AuIKwZezENK8mwLvZ4pnZrZJGAUdEp4vM7JMqkNVxqo+STbBsKnz+MTfWfYEeRQtpyKadgi2z5iywtiywtttaA0utBStoykbql5lNq+Yl3Lcgd32tIRtprdUUs5K9tJJ2sZWzt5bRSmvoroV0r7N9j7SvaMinWzsxxbowaes+TLeObHVF4lQjuZ7gR4GXgJuA69Lc15rZl7kSNbOPgY8rL57jVBNmsGo+LPgwHIsnwpagKPoXrQZgsbXiU+vErFi7n23t2ECDahdtAw1YaG1ZSNuwAiqNxnxFVy3Z1grqpQW00SoGFs1gIDOgDnxNAyZv7cq4rd0Zu7Uny2hR7TI7uxe5FIeZ2VxJV5b2kNSyLOXhOAXH1i2wZCLMfQfmvgtrF+/o33If6DCQm+Z9zdStnVlN4/zImYN17MEk24dJtg9sDW6tWE2fonn00xz6F82mvb7gwKJPObDoU+BfLLA2fLS1Nx9s7c106+jdWk6lKavF8U3CKnDDV4I7NZEtJfD5xzB7FMx5Czau3e7XsBl0OjgcHQbCHsEyzvvP57btVGisoBlvb+3P2/SHLUGRHFA0k8FF0xlQNJNOWk6nOsv5Vp23WGlNeG9rX97Zuh9TrbMrEadC5No69pvxt+uuE8dxqoCtW2HpJJjxWlAY6cqieSfociR0Phza9oGi2vfhXEEzXt86iNe3DqIOW+ijeRxcNI1DiqbSVqs4pc4HnFLnA1ZaE97a2g+W7QtteoJ88qOTjFyD4wNzRYzjGI5TOKxaANNfDgpj3dLt7i26wD5DwtFy96oHbaFO6Nrasg//2HIy++pzjiiazBFFkyjWSk6v8x48MyUo1O4nQI8ToHHbfIvtFDi5uqpuyeFnwNFVLIvjlJ9NX4VWxWcvwpLJ290bt4Vux4aj1b55E6+wELOsA7O2dOCBLcfTXYsYUjSe/o0WB6U75h8w9h7oMAh6nhxaZnXLninm7H7k6qoauisFyYWkucBawmLCEjMbnF+JnLyz7FP49F8wcyRs/iq41WsUWhU9ToC99q+V3VBVh5hhHZmxpSO/HH4iLBwTWmtz34GFY8PRoAn0OBF6nbLbtdSc3OTqqjrazEZKOiuTv5k9XX1iZWSomX2xi/N0ConNX8PMN2Da87D8s+3ue+0HPU8JSqP+HnkTr8ZSVAf2PiQcG9bAzNfh0xdhxUyY9GQ42vWH3qdD16O8FeLk7Kr6BjASODWDnwG7WnE4uyur5sOUZ0ONeNP64NagCfQ8KdSGW3TJp3S1i4ZNYb+zwrF8elDSM98I61wWT4RGzaHXN6H3adCkON/SOnlCZlZ2qDwjaQ6wkqCw/mZmd2cIcxlwGUBxcfGgESNGZExr3bp1NG5cePPzK0NtLBO2lfpLPqbz2nE0XbO9dbGucReWtzmMlS32x4rqVTj5SYtWV4WU5aa4ESz9Oi9ZZ6Vfh2Y5/Yu2bKTllx/TZvl77PHVIgBMRaxq3pdlbY9kCcU0btIkZxo1kdr4XuUq09ChQ8clHQYoU3FIagX8mmBCxIB3gBvMbEW5JK4EkjqY2SJJbYHXgB+WNryYzuDBg23s2LEZ/UaNGsWQIUOqR9A8UavKtGk9fPpvmPIMaxd9SpMmTaBuA+h2HPQ9E1p3q5JsytqHu7q4tl8Jt0xKYiJu15F4z3EzWDoZpjwDs0fD1hIAlpU0pu3RP4Dux4V7VUuoVe9VJFeZJCVWHEme4BHAW8C34vn5wOPAsUkyqArMbFH8XRaNJx4UZXJqC6sXwZSng9KIg90bG7SkycGXhO6ohk3zLKCDBHv1C8chK0I31tTnaLRsPrz1B/job6ELq++ZsGfrfEvrVCNJFEc7M/tN2vmNks6tLoFKI2lPoMjM1sb/xwM37Kr8nWrEDBZPCIOv894N5wDt9od+w5g8t4QhA3zWd0GyZysYfBEcMJw5z/6J/poByz+FTx6GCY/BvsdAv7OhTY98S+pUA0kUx6uSvg08Ec+HAa9Un0g7UQw8o7CqtS7wqJm9vAvzd6qaLSVh7cWkJ7bPjqpTb/vHJtUdNW9UhbPIV1dUTSTXtSqzG6tOPb5sNRi+cW3oxpr0JMx5G2a8Go52+0P/c2HvQ316dC0i13TctWy3UfUj4OHoVQSsA35S3cIBmNlswja1Tk1nw5owzXPyP2H98uDWsBn0OT10b0RbUU4NJL0ba83i2O34YmhRLp4AzTpCv2FhXUi9RvmW1qkkuRYA1r5pEk5+WPM5THoKPvt3WIsB0KJzaF10P75WDag6QNN2cOiVMOjCMGY1+SlYvRDeuR3G3BMrCmeF7i6nRpJoeoekFkB3oGHKLdesJscBggmQiY+H1cgWbYB3GBS6Ljoe6F0XtZ36e0L/s8OakDlvhW6spVPiOMiIYA6m/zluEqYGUqbikPR94BqgIzAeOAR4H7dV5WRi65YdPxIARXVDy8I/ErsnRXVg36HhSK9MTH85HF6ZqHEkaXFcAxwIfGBmQyX1Av63esVyahwb14WuqMn/hLVLgluDJt4t4ezIXvuFI737ctG4cDTfO3Rf9jjBuy8LnCSKY4OZbZCEpAZm9qmkntUumVMzWPN5UBZp6y/CQGj8APhAqJOJpu3h8KvDlN5pL4RnaNV8ePsWGPP3uB7EKxyFShLFsVBSc+BZ4DVJK4F51SmUU+CYweLxocY4773t4xftB0C/c3zqpZOcBk1gwHmhojF7VOji3LYeZETo3tpvGLTtlW9JnTTKVBxmdmb8e72kN4FmgK+j2B0p2Rgsp05+OlhOhTh+cVxQGFVkDsTZDalTF7ofC92OCetBJj4RxkFmvBaO4v3CIHvXb4SwTl5JOqtqINttVb1rZpuqVSqnsFi7BKY+B9P+tX0b1kYtwvhFn9N9/YVTdey0HuSZsB5k6eRw7Nk6dGP1PtWfuzySZFbV/wBns92M+n2SnjSzG6tVMie/bN0Kn38cXtz07qg2vULNb5+hvi+DU700bQeHXhHWg8x4NSwqXDkPxt4LHz8I+3wjLBwt3s/3S9/FJGlxnA/sb2YbACTdTJiW64qjNrJhNXz2cjBgt3phcCuqC/seHRRG2z7+kjq7lvp7QN8zQut20cdhIH3++2GfkJlvQKtu0Oe0YEHZN/LaJSRRHJ8TFv5tiOcNgEXVJpGz6zGDJRPD7JbZo2BL7Incs014WXud4t0CTv6RoOOgcKxdErpOP30hjLe9fSt88NcwRtL7VGjjEz+rk1y2qu4kjGmsBqZIei2eHwd8tGvEc6qVr74MA4+fvhCmQkJ4OTsdHBTG3oeExVuOU2g02QsOuhQGXgBz34KpzwebWNP+FY7WPUKFp9sxYeaWU6XkanGkdkIaBzyT5j6q2qRxqp8tJbDgQ5j+Uhi72LoluO/RKm7F+s3Qt1wgVMpyq1P7qVs/mC7pdix8OScMpE9/Gb6YDu9Mh/fvCmMhPU6C9gf4NPEqIpeRwwdS/yXVB1KG9T8zs83VLZhThZjBilnhhZr5Ony9MrirCDofHhTG3of6NEenZtOyKxx2FRx0WTB7k1qVnprS27htMH3T44SwSt2pMElmVQ0BHgDmEkysd5J0gRs5rAGsXRoUxYxXYeXc7e4tOgfz1t1P8JW5Tu2jbv2wJqT7sWFK7/SXYPqrsHZxWFj4ycNhdmD348KkDx+/KzdJqpi3AMeb2WcAknoAjwGDqlMwp4KsXwFzRsHMkWHee4qGTcNL0uOkMHDoM6Oc3YGm7WDwxTDwwjABZPrLYb/05Z+G4/27QhfWvkdD1yPD/jBOmSRRHPVSSgPAzKZLqleNMjnlpN6mVWGK4uxRsGTS9i1Y6zYIXVHdjwuWR+sU3m3LNYZxbb8SEq5RdaqJsnZSrDHjTEVFwSRO+wFwxI/DVsUzXg/jfSkji+/cCu0HhjGRLkfkW+KCJslbOU7SP9i+A+D5bB84d/KBGayaF0wyzH2H/rM+gjlx5kidetDxIOh2NOx9mM9rd5zS1G0QWhj7Hh12pZz7Dsx6I6wRWTgmHG/fSg9rDS2XByVSQBNGCoEkiuNy4Erg6nj+NvDnapPIyUzJptCamP8ezHsf1mxfSrO1qG54uPcZCp0PDRvoOI5TNg2bQq+Tw/H1qtASmT0aFo2jyZpZ8P7/haNFF+h8WJhEUtx3t5+mnlNxSKoDTDCzXsCtu0YkBwititULYdFYWDAmmP9IbbsK4YHf+1DociQTZn/FUceckD9ZHac20Kh5WPvR6xTYuI7ZL/6d/ZuuhvkfhsklK+fC+EehfuOwCLHTwdBhMDQpzrPgu56cisPMtkj6TNLeZjZ/Vwm127L+C/j8k3AsGrd9Q6QULfcJi/I6HwZt+26bk7513qhdL6vj1GYaNGZlywNgyBDYshkWTwyt/fkfhArd7NHhgLD/TMfBYZC93f7BAGgtJ0lXVQvCyvGPgPUpRzM7rdqk2h0wC5sgLZkUZnssnrDdNlSKhk3DtpodDwqD243b5EdWx9mdqVNvu6mTw34Y3tsFH8LCsaGSt3phOKY8G8K37Ap79Yd2/cNv47Z5Fb86SKI4/rvapdgd2LQ+rGZdNi3sxb10yvaFeCnq7RHMSbc/ICiMVt18pavjFBpN2wervH3PDJYXlk0LXcmfjw8VwS/nhGPqcyH8nm3CuEjxfmFDqlbdoV7DvBahsuSyVdWQMDDeDZgE3GNmJbtKsBrNhjXw5Sz4YkY4ln8KqxdsnyabomHTUCNJ1U5a99jtB92c2kOtmcqbi6I62/dRH/i9MIll+aexF2FiqCCuXx6mys8eFeKoKLRKWvcMm5+17gEt961RMyBztTgeADYTZlGdBPQBrtkVQtUYNm8IxgFXzoWVsZbx5SxYt2znsEV1w0PSpmesefQOfaO+EM9xag9164dKYLv+cABhX5tV82DZVFg6NSiVL2cHE0ArZsFnaXGbtg/jmC27hllcLbpCs04Fue9NLsXRx8z6AUi6h93VIm7JJli3BFYvClNgVy8MrYdVC2Dd0sxx6jYIN71191CbaN0jPBAF+AA4jlONFMXWRcuuYbYWhArnipmh6/qLGeF31bwwdrLm87CuJIWKgiXgZp2geSdo2iFUOJu2h8bFeVvUm0txbDNkaGYlqu0143XLw6yJdcvCbKZ1S8Pv+uXZ4xTVhWYdttcOWnQO4xJNO/rYhOM4manXcHv3VootJaFCumJW6L1ITf9NKZPUgHw6KgrjJ032CkqkSTE03muXmE7JpTj2l7QmJSLQKJ4LMDNrWq2S7WrWLAybwZQmpfGbtAuavlnHoPWb7x20/m4yJlGI5s3L6kN3qp8u173Itf1KuNDvReWoU3d7yySdLZtDT8eq+bHXI87gWrM4VGrXLd2556Pd/vlTHGZWMF9ESScCfwLqAP8ws5urPJNmnaDnyWHqXJO94m/78LubKAfHcQqMOvVij0aXnf22bI69I8tCd3rqf+PqX5BY8Bbk4ur1uwg7Dy4Exkh63symVmlGe7aGIT+v0iQdx3GqjTr1wrhH8067POua0BF/EDDTzGab2SZgBHB6nmVyHMfZbZGVXltQYEgaBpxoZt+P598FDjazq0qFuwy4LJ72ZMeJbum0Br6oJnHzRW0sE9TOcnmZag61sVy5ytTZzBKZpyj4rqqkmNndwN1lhZM01swG7wKRdhm1sUxQO8vlZao51MZyVVWZakJX1SIgvROvY3RzHMdx8kBNUBxjgO6SukqqD3wbeD7PMjmO4+y2FHxXVVx8eBXwCmE67r1mNqUSSZbZnVUDqY1lgtpZLi9TzaE2lqtKylTwg+OO4zhOYVETuqocx3GcAsIVh+M4jlMuao3ikHRi3OZ2pqTrMvjfJml8PKZLWpXmd4GkGfG4YJcKXgaVLNeWNL+CmVCQoEx7S3pT0ieSJko6Oc3vFzHeZ5IKaqP1ipZLUhdJX6fdq7/ueukzk6BMnSW9EcszSlLHNL+CfK8qWaZCfafulbRM0uQs/pJ0RyzzREkD0/zKf5/MrMYfhEHzWcA+QH1gAsEsfLbwPyQMsgO0BGbH3xbxf4t8l6my5Yrn6/JdhoqUiTCA94P4vw8wN+3/BKAB0DWmUyffZaqCcnUBJue7DBUs05PABfH/0cBD8X9BvleVKVM8L7h3Ksp1FDAw23MEnAy8RDBSewjwYWXuU21pcZTXLMl5wGPx/wnAa2b2pZmtBF4DTqxWaZNTmXIVKknKZEDK+nIz4PP4/3RghJltNLM5wMyYXiFQmXIVKknK1AcYGf+/meZfqO9VZcpUsJjZW8CXOYKcDjxogQ+A5pLaUcH7VFsURwdgQdr5wui2E5I6E2qrqQcjcdw8UJlyATSUNFbSB5LOqDYpy0eSMl0PDJe0EPg3oSWVNG6+qEy5ALrGLqzRko6sVkmTk6RME4Cz4v8zgSaSWiWMmw8qUyYozHcqCdnKXaH7VFsUR3n4NvCUmW3JtyBVTKZydbZgXuA7wO2S9s2PaOXmPOB+M+tIaGI/JKk2PKvZyrUY2NvMDgD+E3hUUk3Z7+YnwDckfQJ8g2DVoaa/W7nKVFPfqSqlNryMUD6zJN9mx+6cQjZpUplyYWaL4u9sYBRhF+R8k6RMlwBPAJjZ+0BDgnG2mn6vMpYrdr2tiO7jCH3wPapd4rIps0xm9rmZnRWV3i+j26okcfNEZcpUqO9UErKVu2L3Kd+DOlU0MFSXMKjTle0DXn0zhOsFzCUufEwbHJpDGBhqEf+3zHeZqqBcLYAG8X9rYAY5BtYLqUyEQbwL4//ehLEAAX3ZcXB8NoUzOF6ZcrVJlYMwaLuoEJ7BhGVqDRTF/78Fboj/C/K9qmSZCvKdSpO7C9kHx09hx8Hxjypzn/Je2Cq8aCcD0wm1tV9GtxuA09LCXA/cnCHuxYSB1pnARfkuS1WUCzgMmBRfjEnAJfkuS9IyEQYn342yjweOT4v7yxjvM+CkfJelKsoFfAuYEt0+Bk7Nd1nKUaZh8QM6HfhH6sMa/QryvapomQr8nXqM0OW5mTBOcQlwOXB59BdhQ7xZUfbBlblPbnLEcRzHKRe1ZYzDcRzH2UW44nAcx3HKhSsOx3Ecp1y44nAcx3HKhSsOx3Ecp1y44igDSUMkHZZ2fpSkjyWVSBpWzrR+JGmPSsjSRdJ30s4HS7qjounlk3hdX8i3HLmQ9F+lzt8rZ/yrJU2T9EgF8y+KFk0nS5okaYykrtGvmaQHo7XTWZIekdQi+nXJZCVV0v2SFklqEM9bS5pbVl6FTrRgOzjfchQykq6X9JOqSs8VR9kMIczfTjEfuBB4tAJp/QiosOIgLPDZpjjMbKyZXV2J9MqFpILfarg8JCjPDorDzA7LFjALVwDHmdn5FZTnXKA90N/M+hHsJq2KfvcAs82sm5ntS5iDf3+CbLYQ5u2XJldeu5za9qxVB9FUel6+4bul4pD0vWiTfoKkh6LbqZI+jIbmXpdULKkLYRHNj6P9/SPNbK6ZTQS25kh/T0kvxvQnSzpX0tWEF/NNSW/GcOvS4gyTdH/8f3+s/b0naXZay+Zm4Mgoy4/Ta+2xRnFvrH3Njvml0v5vhf0H3pH0WKaaR8zzr9GA23RJ34zuF0p6XtJI4I1YtnslfRSv1ekx3AeS+qalNyq2iA6S9H4M+56knlmuV6Y0L5T0tKSXFfYK+H1anBMVWn4TJL2RK51SeQ2R9LbCXgpTo9uzksZJmiLpsuh2M9AoXutH0u9XfGH/kFY7PzdDPn8lrAJ/Kd6rljGfifFa9U+7bw9Jehd4qFQy7YDFZrYVwMwWmtlKSd2AQcBv0sLeAOyf6fqW4nbC81z6w5wxrwzlOjDexwnxOjeR1FDSffFafCJpaAyb7ZnIdb+TPGuNJI1QaM09AzTKIOeJkp5MOx8i6QVJdeKznrp3P851saJM/5d2/oKkIfH/Okm/jdfiA0nF0b1Y0jPRfYJij4Wk/4z5Tpb0o+h2s6Qr09Lf1jKQ9FOFlt9ESf8vunVReJcfBCYDnTKFi2F/qfAuvwOU9VyUj3yveMzDCsu+hBWhreN5y/jbgu17sH8fuCX+vx74SYZ07geGZcnjW8Df086bxd+5qXzj+bq0/8MIBvBSaT9JUOx9CGagIbR+XkiLs+08yvkewRxHa2AFUA84kLAiuSHQhLAiNlt5Xo55diesPm1IaF0tTLtO/wsMj/+bx2u5J/Bj4P9F93bAZ/F/U6Bu/H8s8M8MsmdL80KCeYhmUZZ5BLs6bQgWPbuWuocZ0ylVziHA+lTcUvEbEV7GVqXvT/p5vL+vEfZ2KCa0QttluKbb7jdwJ/Dr+P9oYHzafRsHNMoQv2NMYzxwC3BAdD8NeCZD+GeAM8hieiLe42HAvcBFhOdkbq68SsWvH+/Hgen3FriW7fvb9IrXo2GOZyLX/U7yrP1nWn79gRLSVkJH97pRjj3j+V+A4QSF+1pauOZlfC8uBP4v7fwFYEj8b8RV/sDvgV/F/48DP4r/6xCe30GEFdt7Ao0JlgIOiMfotPSnEp7x4wn7t4jwTr5A2HOjC6HSekgMny1cKr894n2aSYb3vqLH7tjiOBp40sy+ADCzlA37jsArkiYBPyUomIoyCThO0u8UWimrK5DGs2a21cymEj5OSXjRgsG8L4BlMd7hwHNmtsHM1gL/yhH/iZjnDMIHold0fy3tOh0PXCdpPMHIW0Ngb4LxvlTL6Bzgqfi/GfCkQp/7bWS+rtnSBHjDzFab2QbCS9WZYGvnLQt7cpBAttJ8lIobuVrSBOADwkvbPfPl2cYRwGNmtsXMlgKjCQq6rDgPRXlHAq203QLu82b2dekIZraQUFP8BeFj8YakY8rIJwk3EZ7xbe9/wrx6ElolY2KcNWZWEsv2cHT7lKDge5D9mch1n5I8a0el5TcRmFi6gFGul4FTY+vqFOA5wnO9j6Q7JZ0IrElwvbKxifChhqD8u8T/RxMUFfEZWU24Rs+Y2XozWwc8DRxpZp8AbSW1l7Q/sNLMFsSyHw98QjBD04vtz+U8C3tqkCPckTG/r8xsDVCluxV6P+J27gRuNbPnY1P0+oomZGbTFbZmPBm4UdIbZnZDpqBp/xuW8tuY9l8Js06Ps4Xy39/S9mdS5+tLyfItM/usdGRJK2IXzLmELj4I3SlvmtmZCl1/ozLkmzFNSQdTvjJlla0U28oT7/WxwKFm9pWkUex8L6qb9dk8zGwjwTjdS5KWEloUfwIGSCqy2LWk0Ne9P+HjkbNCaGYz4sf4nAR5vVGxIgVLslmeiVz3u8xnTUr6OjACuIqwwdHYWHEifqBPiPKcQ+YxnxQl7Hg905+NzRar/VTsfUvxJEHB7kVorUAo+01m9rf0gPEdKn2NMoX7UQVlScTu2OIYCZytuDGLpJbRvRnbzQlfkBZ+LaGLJzGS2gNfmdnDwB8IWzpmSmuppN7xpT8zQdLlloVgVO/U2A/dGPhmjrBnK8yu2ZfQP5/pA/wK8EPFt1dSulnpx4GfEbrmUrXA9Ot6YZZ8c6WZiQ+Ao7R9hlHqHpY3nZR8K6PS6EVozaTYLKlehjhvA+fG/vI2hBrwR2Xk8zZwfpRrCPBFrAlmRdLA+CylFEN/Qm1zJqGG+au04L8itM7mlyFHit8S9p3ImVepOJ8B7SQdGMM1ibX59LL1ILQKUs9Opmci6X3KFu4t4iQRSftFWTMxmvDuXUpQIkhKWb79J+GaDcwSN8VcopKW1IlkO06+Afwg5ldHUjPCNTpD0h6S9iS872/H8I8TtkUYRlAiqbJfHN9ZJHWQ1DZDXtnCvRXzaySpCXBqArkTs9spDjObQnhpRsfuiVuj1/WELpVxwBdpUf4FnKk4OK4wOLgQOBv4m6QpGbLpB3wUa3W/Bm6M7ncDLysOjgPXEZq67xEsW5bFRGCLwoBbzkG9tPKOITRTJxJqk5OAbF1n8wkfwJcIVjU3ZAjzG8LYycRY9vQB2qcIL8ATaW6/B25S2BQnW40sV5qZyrQcuAx4Ot7DVC2tXOlEXgbqSppGmHzwQZrf3TGt0tNpnyFczwmEisjPzGxJGflcDwySNDHmc0Hu4AC0Bf4Vu/kmEmq/qYHai4HuClNxlxMU3uVpcXtKWph2nJ2ecHwPPk6YVyrOJkLL4c543V8j1MD/DBTFbt7HCabjUy3FTM9E0vuULdxfgMbxnt1A6CbaCQubmr0AnMT2LqUOwKj4bj5M6JpD0uWSLs+QzLsEU+NTgTvY8Zpl4xpgaLwe4wim1z8mjDF9BHwI/CN2U6XuRRNgkZktjm6vEmZuvh/TeYoMlcZs4WJ+jxOe0ZeAMQnkToxbx90NkNTYzNYprCF5C7gsPljpYe4nDFY/lSkNp3BRmEn1InC1mf073/I4tR8f49g9uFtSH0Lt8IHSSsOp2cQxgG75lsPZffAWh+M4jlMudrsxDsdxHKdyuOJwHMdxyoUrDsdxHKdcuOJwHMdxyoUrDsdxHKdc/H+9qCFKr3nJxAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "stunting_prevalence_ratio.query(\"stunting_state == 'cat1'\").value.hist(bins=20, density=True)\n",
+    "plt.xlabel(\"cat1 stunting prevalence ratio for SQLNS covered vs. uncovered\")\n",
+    "plt.ylabel(\"Probability density over 288 combinations\\nof (year, sex, age, draw)\")\n",
+    "plt.title(\"Severe stuntining prevalence ratio histogram\")\n",
+    "normal_dist = normal_dist_from_mean_lower_upper(0.85, 0.74, 0.98, scale_factor=1) # 0.85 (95% CI 0.74 to 0.98)\n",
+    "plot_pdf(normal_dist, f'N({normal_dist.mean()}, {normal_dist.std():.2}^2) pdf')\n",
+    "plt.legend();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "c87c082a",
    "metadata": {},
    "outputs": [
     {
@@ -1878,7 +2438,7 @@
        "Name: value, dtype: float64"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1889,8 +2449,47 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "id": "ee8a6c09",
+   "execution_count": 28,
+   "id": "376356a2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x2b3e2a487ca0>"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYoAAAEWCAYAAAB42tAoAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAABSGUlEQVR4nO2dZ5hUVdKA35pAzsGRpOSkBAEDRpAgGDCsWRRMqGsWA66uop+u6GJOqyuKiophUREjKmBCJUhQQHKOImkAYUJ9P85paIbunjuxe2bqfZ77dN9zT6hzU92TqkRVMQzDMIxoJMVbAMMwDCOxMUVhGIZhxMQUhWEYhhETUxSGYRhGTExRGIZhGDExRWEYhmHExBRFAiAijUVERSQl3rIkGiLyqYgMKOy4JRURWSoiPeMtR2EiIv8QkZfymVZFpHmUYxeJyBcFk84AUxR5xj+ou0WkTo7wX/xN2zhOokWlqF4uIjJUREYVZX6q2ldVXw2SPi9xjfggIt1EZGV4mKr+S1WvKOyyVPUNVe0dQKaRIvJAYZdfmjBFkT+WABeEdkSkHVApHoJYKyTxEJHkeMsQD8Rh75QwSs3zqaq25WEDlgJ3A1PCwoYDdwEKNPZh1YHXgA3AMp8myR9L9mn+ABYD1/q0KWFpRwBrgFXAA0CyPzYQ+B54HNjojzUDvvb7fwBvADV8/NeBbGAnkA7c7sOPAn4ANgMzgW4x6nyHl2Mb8DvQA+gD7AYyfL4zw85Pz7C0Q4FR/n9jX88BwHIv613+WLT8JgJXhNX9O3/uNuEUdt+wsvIStwnwja/Tl8CzITkj1L8bsBL4h5d5KXBR2PGRwPPAJ8B2oCdQH/ifv/5LgBt83Pr+WtQKS3+Yzzc11rXMeX5xH3pDgEU+/juhfGOd67B78B8+7TZgGtDIH2sNjAf+9Nf73Bj3xkTgQdw9uRNoDlwKzPX5Lgau8nEr+zjZ/hqn+/MxNPzcA/2A33D35kSgTYzyFbgaWODjPwtI+D3g/wvumVkPbAVmA4cCg3D33G4vz0c+fhtf9mYvS7+wMmsDH/l8puCewe9yyHStl2mJD3sSWOHTTAOOy/GMvAuM8udsNtASuNPLuwLoHdf3XjwLL4lb6EH1D1Ab/8CtBA5mX0XxGvAhUNU/tPOBy/2xq4F5QCOgFjCBfRXF+8AL/sE6APg57GEbCGQC1wMpQEX/cPYCygN1cS/AJ3LKHLbfAPdiORn3sunl9+tGqG8rf6PW9/uNgWZhN/ioSOcnx0OQU1H818vdAdiFfxFEyW8i+778M4Ar/Xm/BljN3hdDXuJOximRcsCxuAc4lqLIBB7z5/gEnEJo5Y+PBLYAx/jzWQn3MrjH598U98I8ycf/GrgyLP9/A//x/wNfS+BG4EegoY//AvBWwHN9G+6F1Ar3Eu2AewFW9tf7Utz9FVJibaOcm4k4RXSIj58KnIJTeOLP1Q6gU9i5XJkjjz3XHfeC3O7PQSpwO7AQKBelfAXGATWAg3CKuU/YPRBSFCf5a1LDy9UGqBd2/R4IyzPVl/kPf/1OxL3AQ9d7tN8qAW39+cqpKMbjnu2KPqy/P78pwGBgLVAhrP5/eRlTcO+OJbiPz1TcPbwkru+9eBZeEjf2Koq7gYdwX8Lj/QVW/4Am475Q2oaluwqY6P9/DVwddqy3T5sCpOEe6Iphxy8AJoTd/MtzkfEM4JecMoft3wG8niPN58CACHk1x33V9ARScxwbSv4URcOw4z8D58fIbyL7vvwXhh2r5PM7MC9xcS+UTKBS2PFROcsOO9bNx68cFvYO8E//fyTwWtixI3NeI9zX4Sv+/xXA1/6/4F40x+f1WuK+2nuEHauHU44pAc7178DpEco7D/g2R9gLwL1R5JsI3J/L/fgBcGPYuYylKP4JvBN2LAnXmu0WJW8Fjs1xXYaE3QMhRXEi7mPtKHzLPizNSPZVFMfhXuRJYWFveTmT/TluFXYsUovixFzOySagQ1j9x4cdOw3Xugn1IlT1edaIlWdRbqWj/yw+vI772muC+wIIpw7uS2BZWNgy3Jc8uOb2ihzHQhzs064RkVBYUo744f8RkTRc0/Y43E2VhLsRo3EwcI6InBYWlopr2eyDqi4UkZtwN/MhIvI5cIuqro6Rf26sDfu/A6iSn7SqusOfo2jpo8WtA/ypqjvC4q7AtfCisUlVt4ftL8Ndx/D0IQ4G6ovI5rCwZOBb//9/wNMiUg/3BZ0dOpbHa3kw8L6IZIeFZeE+NkJEO9eNcN1OkfI8MofsKbj7PRo578e+wL24uoVaWLNjpA+nPmHPg6pmi8gK9j47kcj1flLVr0XkGVzX1MEiMga4VVW3RpFhhaqGn9fQ81sXdz6iPo+RwkTkVuByn7cC1XD3YYh1Yf93An+oalbYPr5emyOUVeTYwFM+UdVluObhycCYHIf/wH11HBwWdhDuywjc2EOjHMdCrMC1KOqoag2/VVPVQ8KLz1Hev3xYO1WthmvmSoz4K3AtihphW2VVHRalrm+q6rHs7V57OEq+4LoNwgf2D4yUZxQi5VcUrAFqiUi4nLGUBEBNEakctn8QrisrRLjsK3BdBeHnt6qqngygqpuAL3Bf7xcCo9V/OpL7tQxnBW7cJbycCqq6Kkr8nGmbRQmflCPPKqp6TYy89tRdRMrjFOFwIE1Va+DGbiRn3CisJuy5EafdG7H32ck3qvqUqnbGdRe1xHW/RZJpNdAox8B86PndgGtdNgw7FuneCT8nx+G60M4FavpzsoXo1zXhMEVRMC7HNTHDvzTxXwLvAA+KSFURORi4Bde9gT92g4g0FJGauAHJUNo1uJfIoyJSTUSSRKSZiJwQQ46quKbqFhFpwN4HIMQ6XD95iFHAaSJykogki0gFP22xYY50iEgrETnRvwD+Yu9gZCjfxjkeqBnA+SKSKiJdgLNjyJ2TSPkVOl7JTwWGikg5EemKa+7nxn0+/nHAqbgByEj8DGwTkTtEpKI/x4eKyOFhcd4ELsGdnzfDwnO7luH8B3ePHQwgInVF5PQA9QB4Cfg/EWnhZyu1F5HauP7+liJysb+GqSJyuIi0CZhvOdx4yQYg07cuwqeorgNqi0j1KOnfAU4RkR4ikorrz9+Fm3iRb3wdjvR5bsfdy+H3cfjz8ROuZXK7r3833P0x2j/bY3D3TiURaY27jrGoilMuG4AUEbkH16IoMZiiKACqukhVp0Y5fD3uhlyMm33zJvCyP/Zf3JjATGA6+7dILsE9cHNw3Q7v4fqfo3Ef0An3lfJxhPweAu4Wkc0icquqrgBOxw3WbcB9Rd5G5PuhPDAM10paixtcv9MfC70oN4rIdP//n7gv1U1ervCXYG5Eyq+ouAjoyt6ZY2/jXkjRWIur02rcTKSrVXVepIj+ZXIq0BHX6vwD92IOfzmOBVoAa1V1Zlh4btcynCd9Pl+IyDbcwPaRMeKH8xjupfwFbiB/BG5cbBvuxX6+r+taXAuyfJBMffobfN6bcC2msWHH5+H6+xf7+7F+jvS/41pRT+PO22nAaaq6O2C9olEN99xtwnUjbcRNIgBX97Zeng98WacBfb0MzwGXhF3v63DXci2uS+4tYt87nwOf4cZIluGUVKTuqoQlNAPEMMo0IvI2ME9V741wrBtusHW/FpdhiMjDuAkVA+ItS1FhLQqjTOK7Ipr5rr0+uBbWB3EWyygBiEhr31UnInIErgv6/XjLVZTYrCejrHIgrlunNm4dzDWq+kt8RTJKCFVx3U31ceMbj+LWTJVarOvJMAzDiIl1PRmGYRgxKZVdT3Xq1NHGjRvHW4yIbN++ncqVK+cesQRgdUlMSktdSks9oGTUZdq0aX+oat1Ix0qlomjcuDFTp0abtRpfJk6cSLdu3eItRqFgdUlMSktdSks9oGTURUSWRTtmXU+GYRhGTBJGUfjVwT+LyEwR+U1E7vPhTUTkJxFZKCJvi0i5eMtqGIZRlkgYRYFb2XiiqnbArWjtIyJH4VaFPq6qzXGrKi+Pn4iGYRhlj4QZo/BG0dL9bqrfFGce+EIf/irOiunzxS2fYSQiGRkZrFy5kr/++mtPWPXq1Zk7d24cpSocSks9ILHqUqFCBRo2bEhqamrgNLkqChE5BpihqttFpD/ODs2T3rBaoSLOheQ0nA+EZ3FmkDeraqaPspIo5oZFZBDOWxVpaWlMnDixsMUrFNLT0xNWtrxidYk/VapUIS0tjQYNGhAyS5+VlUVycsn3xlpa6gGJUxdVZcuWLcycOZP09PTcE3iCtCieBzqISAecJceXcP4XYlkzzRfemFpHEamBWxLfOg9pXwReBOjSpYsm6gyDkjD7IShWl/gzd+5cGjZsuEdJAGzbto2qVavGUarCobTUAxKrLlWrViU9PZ0uXboEThNkjCLTdwudDjyjqs/ilrAXGaq6GedEpytQQ/Y6KG9IIdilN4zSRLiSMIzcyM/9EkRRbBORO3Gmfz/2vgKCd24FxNvSr+H/V8T5zJ2LUxghnwYDKOU2VQzDMBKNIIriPNyMpMtVdS3uq/7fsZPki3rABBGZBUzB+ZAdh/PvfIuILMQZcBtRBGUbhpFPRITBgwfv2R8+fDhDhw7ds//EE0/w2mvOW/Cff/5Jr169aNGiBb169WLTpsheXu+44w6OPPJIDj30UN5+++094ZdffjkdOnSgffv2nH322YH62R966CGaN29Oq1at+PzzzyPGWbJkCUceeSTNmzfnvPPOY/du5/7iscceo23btrRv354ePXqwbNneodnly5fTu3dv2rRpQ9u2bVm6dOl+5aampvL66/t6kX3jjTdo37497dq14+ijj2bmTOeOZPfu3Rx//PFkZmaSXyZOnMipp54KwK5du+jZsycdO3bc5xzmh1zHKLxyeCxsfzn7+4guMKo6CzgsQvhi4IjCLs8wioPGQz7Od9qlw04pREmKjvLlyzNmzBjuvPNO6tSps8+xzMxMXn75ZaZPd36ohg0bRo8ePRgyZAjDhg1j2LBhPPzww/uk+fjjj5k+fTrff/895cqVo1u3bvTt25dq1arx+OOPU62acw53yy238MwzzzBkyBCiMWfOHEaPHs1vv/3G6tWr6dmzJ/Pnz99vYPmOO+7g5ptv5vzzz+fqq69mxIgRXHPNNRx22GFMnTqVSpUq8fzzz3P77bfveelecskl3HXXXfTq1Yv09HSSkvZ+d7/++ut89tlnzJ07l7PPPpvq1avTr18/AJo0acKkSZOoWbMmn376KYMGDeKnn36iXLly9OjRg7fffpuLLroon1djL7/84owhz5gxo8B55dqiEJGzRGSBiGwRka0isk1EIjkkNwyjDJKSksKgQYN4/PHH9zv29ddf06lTJ1JS3Dfphx9+yIABzr/PgAED+OCDD/ZLM2fOHI4//nhSUlKoXLky7du357PPPgPYoyRUlZ07d+ba3/7hhx9y/vnnU758eZo0aULz5s35+eef94mjqnz99decffbZ+8nVvXt3KlVyrtWPOuooVq5cuUfGzMxMevXqBbjZZ6F4X375Ja+99hqffPIJzZs354svvuBf//rXnpbD0UcfTc2aNffLE+CMM87gjTfe2K8eS5cupXXr1lx00UW0adOGs88+mx07dgDw2Wef0bp1azp16sSYMc4h4vr16+nfvz9TpkyhY8eOLFq0KOZ5yo0gs54ewbkiTIxJwIZhROYFNxGxUnY2JBXiWtqrJuUa5dprr6V9+/bcfvvt+4R///33dO7cec/+unXrqFfPefU98MADWbdu3X55dejQgfvuu49Bgwaxa9cuJkyYQNu2bfccv/TSS/nkk09o27Ytjz76aEy5Vq1axVFHHbVnv2HDhqxate98mI0bN1KjRo09yixSHIARI0bQt29fAObPn0+NGjU466yzWLJkCT179mTYsGEkJyfTs2dPevbsuSfdAQccwPjx4yPOegrPE+DQQw9lypQpEevy+++/M2LECI455hguu+wynnvuOa677jquvPJKvv766z3dZqEyX3rpJYYPH864ceNinqMgBLmb1pmSMAwjFtWqVeOSSy7hqaee2id8zZo11K0b0SApIhKxRdC7d29OPvlkevXqxQUXXEDXrl336Sp65ZVXWL16NW3atClw33tQRo0axdSpU7ntttsA16X27bffMnz4cKZMmcLixYsZOXJknvKcMGECI0aM2KfrLTk5mXLlyrFt27b94jdq1IhjjjkGgP79+/Pdd98xb948mjRpQosWLRAR+vfvn/9KxiBIi2Kq9yf8AWEOxFU1ltN3wzCKG//lvyNOc/ZvuukmOnXqxKWXXronrGLFivusGk9LS2PNmjXUq1ePNWvWcMABB0TM66677uKGG26gatWqXHjhhbRs2XKf48nJyZx//vk88sgj+5SXkwYNGrBixYo9+ytXrqRBg33X7NauXZvNmzeTmZlJSkrKfnG+/PJLHnzwQSZNmkT58uUB1+ro2LEjTZs2BVyX0Y8//sjllwezMDRr1iyuuOIKPv30U2rXrr3PsV27dlGhQoX90uRUqsU5LTpIi6IasAPoDZzmt1OLUijDMEoetWrV4txzz2XEiL0TE9u0acPChQv37Pfr149XX30VgFdffZXTTz99v3yysrLYuHEj4F6os2bNonfv3qjqnrxUlbFjx9K6tVuT+/7773PnnXful1e/fv0YPXo0u3btYsmSJSxYsIAjjth3boyI0L17d95777395Prll1+46qqrGDt27D5K7fDDD2fz5s1s2LABcGMx4d1jsVi+fDlnnXUWr7/++n4KcOPGjdSpUyeieY3ly5czefJkAN58802OPfZYWrduzdKlS/eMQbz11luBZMgruSoKVb00wnZZkUhjGEaJZvDgwfzxxx979vv27cs333yzZ3/IkCGMHz+eFi1a8OWXX+6ZsTR16lSuuOIKwNmvOu644zj88MMZNGgQo0aNIiUlBVVlwIABtGvXjnbt2rFmzRruueceABYtWrRnoDucQw45hHPPPZe2bdvSp08fnn322T3dWCeffDKrV68G4OGHH+axxx6jefPmbNy4cU/L4LbbbiM9PZ1zzjmHjh077pm5lJyczPDhw+nRowft2rVDVbnyyisDnaP777+fjRs38ve//52OHTvus0J6woQJnHJK5NlurVq14tlnn6VNmzZs2rSJa665hgoVKvDiiy9yyimn0KlTp6gttIKSq89sEWkIPA0c44O+BW5U1ZXRU8WXLl26qDkuKnqsLrlT1NNj586dS5s2bfYJSyRzEQBnnnkmjzzyCC1atMhTurzUo3///jz++ONRx0PiTdC6nHXWWQwbNmy/lsbSpUs59dRT+fXXXwtFnkj3jYhMU9WIdj2CdD29AowF6vvtIx9mGIaRK8OGDWPNmjVFWsaoUaMSVkkEZffu3Zxxxhn7KYlEIIiiqKuqr6hqpt9GAiX7ihiGUWy0atWK448/Pt5iJDzlypXjkksuiXiscePGhdaayA9BFMVGEekvIsl+6w9sLGrBDMMIRm7dx4YRTn7ulyCK4jLgXGAtsAZnoC/6fDTDMIqNChUqsHHjRlMWRiBUlY0bN0acfhuLILaelgH98iuYYRhFR8OGDVm5cuWeaZoAf/31V55fBIlIaakHJFZdQh7u8kJURSEit6vqIyLyNM4l6T6o6g15F9EwjMIkNTWVJk2a7BM2ceJEDjtsP/uaJY7SUg8o+XWJ1aIIme1IzHmmhmEYRrEQVVGo6kf+7w5VfTf8mIicU6RSGYZhGAlDkMHs/dfFRw4zDMMwSiGxxij6AicDDUQk3CRkNSD/LpgMwzCMEkWsMYrVuPGJfsC0sPBtwM1FKZRhGIaROMQao5gJzBSRN1U1oxhlMgzDMBKIIP4oGovIQ0BbYM9EYFVtWmRSGYZhGAlDUKOAz+PGJboDrwGjilIowzAMI3EI0qKoqKpfiYj4VdpDRWQacE8Ry2YYZZr8migf2adyIUtilHWCKIpdIpIELBCR64BVQJWiFcswDMNIFIJ0Pd0IVAJuADoDFwMDilIowzAMI3EIYhRwiv+bjlmNNQzDKHPkqihEpCVwG3BweHxVPbEI5TIMwzAShCBjFO8C/wH+C2QVlSAi0gg3oyoNZ632RVV9UkSGAlcCITvK/1DVT4pKDsMwDGNfgiiKTFV9vsglcdNvB6vqdBGpCkwTkfH+2OOqOrwYZDAMwzByEERRfCQifwfeB3aFAlX1z8IURFXX4DzooarbRGQu0KAwyzAMwzDyThBFEZrhdFtYmAJFtjJbRBoDhwE/AccA14nIJTjbU4NVdVNRlW0YhmHsiySar10RqQJMAh5U1TEikgb8gVNO/wfUU9XLIqQbBAwCSEtL6zx69OhilDo46enpVKlSOpahWF1yZ/aqLYWeZ240qZ5cKq6L3V/FS/fu3aepapdIx6IqChE5UVW/FpGzIh1X1TGFKGOozFRgHPC5qj4W4XhjYJyqHhorny5duujUqYnpmG/ixIl069Yt3mIUClaX3Mnv6uqCMLJP5VJxXez+Kl5EJKqiiNX1dALwNXBahGMKFKqiEBEBRgBzw5WEiNTz4xcAZwK/Fma5hmEYRmximRm/1/8W1yK7Y3CrvmeLyAwf9g/gAhHpiFNOS4GrikkewzAMg2AL7moD9wLH4l7W3wH3q+rGwhREVb8DJMIhWzNhGIYRR4LYehqNW+z2N+Bs///tohTKMAzDSByCTI+tp6r/F7b/gIicV1QCGYZhGIlFkBbFFyJyvogk+e1c4POiFswwDMNIDKK2KERkG25MQoCb2OvVLglnSfbWGGlrAvWBncBSVc0uJHkNwzCMYibWrKeqeclIRKoD1wIXAOVwYxkVgDQR+RF4TlUnFEBWwzAMIw4EGaNARNoDjdnXzHjOdRTv4ay/Hqeqm3Ok7wxcLCJNVXVEQQQ2DMMwipcg02NfBtoDvwGhLqT9Ftypaq9oeajqNGBa/sU0DMMw4kWQFsVRqto2aIYiMgpnq+lbVZ2Xb8kMwzCMhCDIrKfJIhJYUeDMcNQDnhaRxSLyPxG5MX/iGYZhGPEmSIviNZyyWIvzRyGAqmr7SJFVdYKIfAMcDnQHrgYOAZ4sHJENwzCM4iSIohiBt8HE3jGKqIjIV0BlYDLwLXC4qq4viJCGYRhG/AiiKDao6tg85DkL6AwcCmwBNovIZFXdmR8BDcMwjPgSRFH8IiJvAh+xryvUiGbGVfVmAO/3eiDwCnAgUL6gwhqGYRjFTxBFURGnIHqHhUX1RyEi1wHH4VoVS4GXcV1QhmEYRgkkV0WRD38UFYDHgGmqmpkvqQzDMIyEIdfpsSLSUETeF5H1fvufiDSMFl9Vh6vqT0AtETkotBWq1IZhGEaxEWQdxSvAWJyRv/q4sYpXokUWkdNEZAGwBLfwbinwaYElNQzDMOJCkDGKuqoarhhGishNMeI/ABwFfKmqh4lId6B/AWQ0jLjTeMjH8RbBMOJGkBbFRhHpLyLJfusPxHKDmuHdpCaJSJK3GNulUKQ1DMMwip0gLYrLgKeBx3GznX4AYg1wbxaRKsA3wBsish7YXlBBDcMwjPgQZNbTMqBfHvI8Heew6GbgIqA6cH++pDMMwzDiTpBZT6+KSI2w/Zre9HikuMnAOFXNVtVMVX1VVZ/yXVGGYRhGCSTIGEX7cEdEqroJOCxSRFXNArK9tzvDMAyjFBBkjCJJRGp6BYGI1MolXTowW0TGEzY2oao3FEhSwzAMIy4EURSP4syMv+v3zwEejBF/DFHMexiGYRgljyCD2a+JyFTgRB90lqrOiRH/1cISzjAMw4g/QVoUeMUQVTkAiMhs3PTZaHlEdHRkGIZhJDaBFEVATvW/1/rf1/1vf2IokBAi0gjnTS/Nx39RVZ/0YyJvA41x5kDODY2XGIZhGEVPkFlPgVDVZX7NRS9VvV1VZ/vtDvY1UR6NTGCwqrbFmQC51vvqHgJ8paotgK/8vmEYhlFMxFQUIpIS9r+KiHTxX/i5JJNjwnaOzq0cAFVdo6rT/f9twFygAW4BX2jc41XgjNzyMgzDMAoPUY3cKyQiA3EznjYCNwLP4izCtgRuV9W3oqTrjHNWFFpLsRm4LKQEAgkl0hhnAuRQYLmq1vDhAmwK7edIMwgYBJCWltZ59OjRQYsrVtLT06lSpUq8xSgUylJdZq/aUozSFIwm1ZNLxXUpS/dXItC9e/dpqhrRLl8sRTEb6A5UBWYCh6nqIhFJA8bnNjgdWnSnqnl6wrydqEnAg6o6RkQ2hysGEdmkqjVj5dGlSxedOnVqXootNiZOnEi3bt3iLUahUJbqUpKsx47sU7lUXJeydH8lAiISVVHE6hLKUtU/VHUJkK6qiwBUdV2QQlV1Sz6URCrwP+CNMJ/c60Sknj9eD1iflzwNwzCMghFr1tNyEXkI16KYJyKP4hbS9QTWFLYgvltpBDBXVR8LOzQWGAAM878fFnbZhmEYRnRitSj6A1uBlTjrsZOBO3HTVwcWgSzHABcDJ4rIDL+djFMQvbzXvJ5+3zAMwygmorYoVHUr8FBY0Ht+yxMi0gVYraqrY8VT1e8AiXK4R17LNQzDMAqHqC0KPxV2goiMEpFGIjJeRDaLyBQRiWg9NgrXAx+LyNsFF9cwDMMobmKNUTwH3AvUwHm1u1lVe4lID3+sa5ACVHUAgIhULZiohmEYRjyINUaRqqqf+vUSqqrv4f58BVSIlkgc/UXkHr9/kIgc4RfRGYZhGCWMWIriLxHpLSLnACoiZwCIyAlAVox0odbGBX5/G26xnmEYhlECidX1dDXwCJANnARcIyIjgVX4FdBROFJVO4nIL+A84olIuUKS1zAMwyhmYs16molTECFu9FtuZHjf2QogInVxysYwDMMogeRmFLC1iPTwZjXCw/vESPYU8D5wgIg8CHwH/KvAkhqGYRhxIdb02Btwq6CvB34VkdPDDkd98avqG8DtuDUYa4AzVPXdaPENwzCMxCbWGMWVQGdVTffWXN8Tkcaq+iTRF8bhzZCvB94KC0tV1YxCktkwDMMoRmIpiiRVTQdQ1aUi0g2nLA4mhqIApgONgE0+Xg1grYisA65U1WmFILdhGIZRTMQao1gnIh1DO15pnArUAdrFSDceOFlV66hqbaAvMA74O27qrGEYhlGCiNWiuATnnnQPqpoJXCIiL8RId5SqXhmW5gsRGa6qV4lI+YKJaxgFI5pficHtMhlYgnxOGEZxEmt67MoYx76PkecaEbkDCLmYOw/XOknGpskahmGUOHL1ZZ0PLgQaAh/47SAflgycWwTlGYZhGEVIrK6nfKGqf+Cm1EZiYWGXZxiGYRQtMRWF7y76UlW7B83Qr8S+HTiEMOOBqnpifoU0DMMw4kfMridVzQKyRaR6HvJ8A5gHNAHuA5YCU/IroGEYhhFfgnQ9pQOzRWQ8sD0UqKo3RIlfW1VHiMiNqjoJmCQipigMwzBKKEEUxRi/BSW0AnuNiJwCrAZq5VUwwzAMIzHIVVGo6qsiUhE4SFV/D5DnA76rajDwNFANuLlgYhqGYRjxIldFISKnAcOBckATv1r7flXtFym+qo7zf7cAgQfBDcMwjMQkyDqKocARwGYAVZ0BNC0yiQzDMIyEIoiiyFDVLTnCbIW1YRhGGSHIYPZvInIhkCwiLYAbgB+KVizDKLlU4i/qyUaqs51qsp0q/EWSc/iIAtuoyFatzBYqs1ZrsZ2K8RXYMHIhiKK4HrgL2AW8CXwOPBC0AO/waK2q/pQvCQ0jganMTtrIMtomLaOlrKSRbKCmbMtTHpu1Ciu1LvO1IXOyD2aOHkw6lYpIYsPIO0EURWtVvQunLPLDkUA7EUlR1b75zMMwEob6/MFRSXPomjSHlkkrEd9aCJFBCqu1Npu0KlupxDatRLZ34ZKEUkV2Up3t1JRt1JM/qSHp1JB0DmUJZyV/C8ACbcCP2W2ZnN2WlXpAnuSbvWpLvizhLh12Sp7TGGWDIIriURE5EHgPeFtVf81LAar6jyDxRORlnL+L9ap6qA8bivO0t8FH+4eqfpKX8g2jMKjCDk5ImkWv5Kk0lTV7wjNJZkF2Q37Tg5mXfRBL9UA2UB0NaG9TyKYuWzhY1tEqaQWHyFJaJq2khayiRfIqLk4ez1I9kC+yujAxu4O1NIy4EGQdRXevKM4FXhCRajiFEbH7SUT+D7jP+67Ax39SVS/NpaiRwDPAaznCH1fV4bnJaRhFQSNZx5lJ33NC8kxSvXuW7VqRn7UVP2a3ZXp2C3ZRLt/5K0mspybrtSZTsloDUJ7ddJRFHJU0hyOT5tJY1jIoZRyX8hnfZbdjTNaxLNMDC6V+hhGEQNZjVXUt8JSITMAZ/LuH6OMUKcBPInIpkIZ7+T8doIxvvG9uw4g7rWU55yRP4vCkeXvCZmY344vsLvyY3ZaMwje8vIddlOMnbcNPWW1IycrkiKR59E6aymFJC+me9Avdk35hWnZL3ss6gd+0cZHJYRghRFVjRxBpg3M+dDbwB/A28D9VXR8jTQ+c+9NNwPGqGsi8uFcU43J0PQ0EtgJTgcGquilK2kHAIIC0tLTOo0ePjhQt7qSnp1OlSpV4i1EoxLMus1flnLFdMNIqwrqdUH33Wtpt+Yr6O50RgmxJYXHlTsyv2pX01NqFWmZeqZy5iZbbJtM0fRrJ6izlrK3Qglk1erK5XL098UJ1ySvtGuTF9mfRY89K8dK9e/dpqtol0rEgimIyzlvdu6q6OrfCROR44HlgFM63dk3g8oBpG7OvokjDKScF/g+op6qX5ZZPly5ddOrUqblFiwsTJ06kW7du8RajUIhnXaK5NM0vd7XdxI75X9EtaQaC8hflGJt1NGOzurKVxHrAq7KD05Inc3ry91RkFwCTsjswMvMkNlKdwe0yeXR23ls8iTaYbc9K8SIiURVFkDGKriJSDmgpIrWA31U1I0aS4cA5qjrHF34W8DXQOq+Cq+q60H8R+S+ulWIYhUYyWZyaNJmTV3/FxqTdZJHMJ1lH8E5WN7YkmIIIsY1KvJnVg3FZR3FO8iROTv6JE5JmcmS5uYzO7E6SHkER+CQzyjBBbD2dgBtgXgoI0EhEBqjqN1GSdPV+LABQ1TEiMik/wolIPVUNTTE5E8jTjCvDiEVzWclNKWM4SNaRosrP2W14KfNk1hLfLqagbKUyI7JO5qOsrlyW8ilHJ/3GwJTPqbR2Gh/J35inB8VbRKOUEOSz4zGgd8hyrIi0BN4COkeJ30xEngfSVPVQEWkP9COXRXoi8hbQDagjIiuBe4Fu3gih4hTVVQHkNYyYlCODC5O/4ozk70hCWau1mF+3Dw9sOSTeouWL9dRkWOaFHCYLuCplHIdlbODh1BcZm9WVUVm9CjQryzAgmKJIDTcvrqrzRSQ1Rvz/ArcBL/j4s0TkTXJRFKp6QYTgEQHkM4zANJNV3JryDg3kD7IR3s86ljezenBdxWDrHhKZX7QF12dcz3+rfUmNnd9xevIPHJk0j+GZ5zJfG8VbPKMEE0RRTBWRl3CD0wAX4WYgRaOSqv4sIuFhmfmUzzAKBSGbM5O+4+KUL0kmi+V6AE9lnhX2Ai0dt2gGKcyu0ZMPVrbjxpQxNJa1PJL6Am9m9eDdrBMCLwQ0jHCCKIprgGtxxgABvgWeixH/DxFphusuQkTOBtbEiG8YRUp10rk15R06JC0CYFzWUYzM6sNuYjWMSzaLtAGDM67hkuQvOD35e/onf8lhspB/Z57Hn1SLt3hGCSPIrKdduHGKxwLmeS3wItBaRFYBS4D++ZbQMArAIbKU21NGU1O2sUUr80Tm35imreItVrGQQQojsk5menYLbk55j0OSlvJE6rMMzzyXWdos3uIZJYhCb4eq6mJV7QnUxRkUPFZVlxZ2OYYRG+XMpG95MPUlaso2fs1uzA0Z15UZJRFOaOxiZnYzakg696e+wjnJExFzK2MEpNAVhYjc6O077QAeF5HpItK7sMsxjGiUZze3przDpSmfkYQyJus47s68nE1luMtlC1W4J3Mg72R1Iwnl4uTx3JEymgp+wZ5hxCJXRSEi7fKY52WquhXoDdQGLgaG5UM2w8gzddjCsNT/cnzSLHZSnocyL2RkVh+ybRAXJYlRWb24P+NidlKeo5N+45HUFzmAiFZxDGMPQZ6e50TkZxH5u4gEMQYTmu50MvCaqv4WFmYYRUYLWcljqc/RTFazTmtxW8ZVTM4umWsjipKp2prBGdewWuvQWNbyWOpztJFl8RbLSGByVRSqehxuSmwjYJqIvCkivWIkmSYiX+AUxeciUhXzsW0UMV2TfmNY6n+pIenMym7KLRnXsFzT4i1WwrJS6zI442qmZbekmuzggdSXYeFX8RbLSFACtcdVdQFwN3AHcALO5Pg8b8cpJ5cDQ4DDVXUHUA7IzReFYeQTN2g9JOUtUsnki6wu3Js5kG3m4CdXtlOR/8u8mI+zjnK+Nr66H6a/DrkYCjXKHkFsPbXHvehPAcYDp6nqdBGpD0wGxoTHV9VsYHrY/kZgY2EKbRjgFtENSv6YU5J/BGBk5kmMyT4O6+kMTjZJvJB1Kmu0Fk/JDzDlJUhfB8feDEnJ8RbPSBCCtCiexr34O6jqtao6HcCbDb+7KIUzjGikkskdKW9zSvKPZJLMI5nnMyb7eExJ5AdhbPYx0Ov/ILkczP0Ixt8DmTYjynAEURTvq+rrqrrHFYqI3Aigqq8XmWSGEY1d6dyX8gpHJ/3KTspzT8ZAvsvO6+Q8Yz+aHAenPgblq8LS72DcLfDX1nhLZSQAQUx4XAI8kSNsIPBkYQtjGLmy40/49HYOTVrKJq3KvZkDWKr1ck9n5ErIGVQjOYv7Ul6lzqrvWTbtHO7JGBhzDUqiOTwyCp+oLQoRuUBEPgKaiMjYsG0C8GfQAkRkrt+uKwyBjTLMtnUw9nr4YwFrtDa3ZVxlSqIIWKFp3JZxFSu1LgfLOh5O/a+ttSjjxGpR/IAz5lcHeDQsfBswK2gBqtpGRGoDR+VLQsMA2LwCPr4F0tdD7WbcsaQ3m6kab6lKLRupzpCMKxma+irNZRX/Tn2BuzMvZYVNOS6TRG1RqOoyVZ2oql1VdVLYNl1VI9pkFpFk3+LImddGVS1cJ8dG2eHPxa4lkb4e0g6F0540JVEMbKUyd2Vcxq/Zjakp23go5SWaiBmCLovE6nr6zv9uE5GtYds2EYk4wuVdoGYHXMFtGLmzYT58dCPs3AQNOsEpw91gq1Es7KQCQzMH7lmY96+UEbSQlfEWyyhmYrUojvW/VVW1WthWVVVjWVdLB2aLyAgReSq0FbbgRhlg3RwYd7ObeXPQUdBnGKRWjLdUZY7dpPKvzIv4MbstlWUnD6S+TFtZGm+xjGIkiFHAZiJS3v/vJiI3iEiNGEnGAP8EvgGmhW2GEZy1v8LHg2F3OjQ5Hno/ACnl4y1VmSWDFB7OPJ9vs9tRkV0MTX2VQ2RJvMUyiokg02P/B3QRkeY4h0QfAm/ibDnth6q+WnjiGWWSNbPg0zsgYwc0OxG63wXJQW5VoyjJIpnhmeeSmZJM96QZ3Jf6KvdnXBxvsYxiIMjTl62qmSJyJvC0qj4tIr9EiywiLYCHgLZAhVC4qjYtsLRGqSM0dz/EIbKEe1NfowK7mZTdgceXdCL7y8/jJJ2REyWJJzL/RnZyEj2Sp3Nv6muw8hho2DneohlFSJCV2RkicgEwABjnw2I5G34FeB7nrb478BowqiBCGmWDcCUxIbsjj2WebX4kEhAliaeyzuTzrMOdMcHPhsBK610uzQR5Ci8FugIPquoSEWkCxDLdUVFVvwLET7EdijMoaBhR2VdJHMYTmX9DTUkkLEoSz2X144usLpC125RFKSeIP4o5qnqDqr7l95eo6sMxkuwSkSRggYhc57usqhSSvEYp5BBZuk9L4onMs0xJlACUJJ7NOh1an+qUxed3wipTFqWRILOejhGR8SIyX0QWi8gSEVkcI8mNQCXgBqAz0B/XbWUY+9FalnNv6qthSsJaEiUJJQmOGwytT3HWZj+7E1bPiLdYRiETZDB7BHAzboprVm6RVXUKgIhkq6o5LDKis24O96WO3DNwbUqihJKUBMfdCpoNv3/quqH6PgL12sdbMqOQCPJUblHVT1V1vTfFsdE7I4qIiHQVkTnAPL/fQUSey60QEXlZRNaLyK9hYbV8a2aB/60ZpFJGCWD9PPjkViqyi2+z2/F45tmmJEoySUlw/O3Qojdk7HTTm9f+mns6o0QQ5MmcICL/9gqgU2iLEf8J4CS8VztVnQkcH6CckUCfHGFDgK9UtQXwld83Sjp/LIBPboXd2/kh+1AezTzXZjeVBpKSoNud0LynWwPz6e3ug8Ao8QTpejrS/3YJC1PgxGgJVHWFyD6exoJ0WX0jIo1zBJ8OdPP/XwUm4vx2GyWVjYucFdhd26Dxsfx7yZGmJEoTSUnQ/R+gWbBogvsgOPVxqNMi3pIZBUC0kB2pi8h7wGPAMzglcyPQRVXPD5C2MTBOVQ/1+5tVtYb/L8Cm0H6EtIOAQQBpaWmdR48eXeC6FAXp6elUqVI6JoHltS4Vdq6j5fznSM3YxpbqbVnUbACz1uwoQgmDk1YR1u3MPV5JoLjr0q7B/jZAJTuLpotfo8bm2WSmVGJ+y7+zs1L9POVblp+VeNC9e/dpqtol0rFcFYWIpAH/Auqral8RaQt0VdURUeLXwXm/64lzYPwFcGOscY2wtI2Joij8/iZVzXWcokuXLjp16tTcosWFiRMn0q1bt3iLUSjkqS6bVzgrsDs2QsPD4aR/QUq5/VZmx4vB7TJ5dHbpMBNS3HWJ6uEuKwO++CcsnwwVa8CpT0CtJoHzLbPPSpwQkaiKIkibfyTwORD6HJgP3BQjvqrqRaqapqoHqGr/IEoiCutEpB6A/12fz3yMeLJ1jbMCu2Mj1D/MG/grF2+pjKImORV63e8+DHZudl2Om1fEWyojHwRRFHVU9R0gG8A7LYo15vCjiLwrIn0lx0BFPhjL3jUYA3AGCY2SxLZ1MO4m2L4BDmwHfR6C1Aq5JjNKCSnl4KQH3QfCjj/dB8PW1fGWysgjQRTFdu/KVAFE5ChgS4z4LXFWZi/Brc7+l4i0zK0QEXkLmAy0EpGVInI5MAzoJSILcF1ZwwLIayQK6Rvci2HbWjigLfR92PxJlEVSyrsPhAPbuQ+GcTe7DwijxBBEUdyC+7JvJiLf44z8XR8tsjrGq+oFwJW4lsDPIjJJRLrGSHeBqtZT1VRVbaiqI/yajR6q2kJVe6rqn3mrnhE3dvwJH98MW1dBnZZw8iNQrnK8pTLiRWpF96FwQFv34TDuZvchYZQIgth6mg6cABwNXAUcoqqzosUXkdoicqOITAVuxSmVOsBgnB8Lo7Szc5N7EWxeAbWbwSmPmvtSw30onPwI1G3lPiDG3eQ+KIyEJ+rUCBE5K8qhliKCqo6JcnwyzrrsGaoa7lx3qoj8J59yGiWFv7bAx7fCpqVQs7FTEhViec41yhTlq8LJw92HxMaF7ve0J6CiGV1IZGLNoTvN/x6Aa0187fe7Az/gXJ5GopVGmXObi9VZo6Sza5tTEhsXQvWGbqGVvQCMnFSoBqcMh49uch8UHw9290qF/ddjGIlB1K4nVb3UG/VLBdqq6t9U9W/AIURwXCQi/xWRdpGUhIhUFpHLROSiwhTeSCB2pcMnt8Ef86FaAzdnvlKteEtlJCoVazrlUOMgv1p/MPy1Nd5SGVEIMpjdSFXXhO2vAw6KEO9Z4J8iMtdPj33OG/r7FtcCqQq8V3CRjYRj9w5nBG79XKhaz70AqtSNt1RGolOplrtXqjf09r9uc61SI+EIsnzzKxH5HHjL758HfJkzkqrOAM4VkSo4u1D1gJ3AXFX9vXDENRKO3d7427pfocoB7sGvmhZvqYySQuU6rvX50Q2wYZ5TFicPh/KJbe6irBFk1tN1wH+ADn57UVVjTY9NV9WJqvqWqn5gSqL0kpS1y/keWDsbKteF056EavXiLZZR0qhS1ymLqvVcq/TT22H39nhLZYQRyCCMqr4PvF/EshgliYydNF84AljnlcQTUC1vRt8MYw9V01xr9KMbYd1v8MntJFXtF2+pDI/ZdzbyTsZO+GwIVbcthEq19/YzG0ZBqFbPtUqrHADrfqXFghdc16YRdwpNUYjI6/73xsLK00hAvJJg9QwyUqu5B7tGo3hLZZQWwpRFlfSlbszClEXcyVVRiMhpIhJEoXQWkfrAZSJS07sx3bMVXFQj7oRmN62eAZVq83ura01JGIVPtfpw2pPsLlfDTZL45DYbs4gzQRTAeTjjfo+ISOsY8f6Dc1faGpiWY0tM5xBGcEKzm9bMdN1Npz3Jrgo2BdYoIqrVdx8iVdKcsvj4Vps6G0eCzHrqDxwGLAJGishkERkkIlVzxHtKVdsAL6tqU1VtErY1LRrxjWIhtJguNLup31PWkjCKnN3l3QeJmw01xykLW5QXFwKNUajqVtxiudG49RFnAtNFZL9psqp6jYh0EJHr/Na+UCU2ipe/tjq/x+t+dV93/Z6ygWuj+AiNWVSr79ZZfHyLc4JkFCtBxihOF5H3gYk40x1HqGpf3JqKwRHi3wC8gbMRdQDwRiSFYpQAQlZgQyuuQw+sYRQnVdPgtKf2ruD+6EazOlvMBGlRnAU8rqrtVPXfqroeQFV3AJdHiH8FcKSq3qOq9wBH4fxSGCWJ7RvdAxky8NfvaVtMZ8SPKnWdsqjZ2BkSHHs9pJtn5OIiiKJYq6rfhAeIyMMAqvpVhPjCvq5Ss3yYUVLYttaZVNi0zD2Y/Z42201G/Klc2y3srN0ctqx0ymLLylyTGQUniKLoFSGsb4z4rwA/ichQERkK/AiMyIdsRjzYtAw+vM49gHVauu4mswJrJAohq7MhT3ljr4c/F8dbqlJPVEUhIteIyGygtYjMCtuWAFE93KnqY8ClwJ9+u1RVnyhkuY2iYMN89+Bt3+D8G5/6OFSsEW+pDGNfKlRzDrEadHJjFWNvcONoRpERy9bTm8CnwEPAkLDwbbn5rvbuU6cXXDyj2Fg9Az7/h1vY1OhI6HU/pFaIt1SGEZlylaDPw/DlUFj2PYy7BXo/AA07x1uyUkmsridV1aXAtcC2sA1baV3KWPLt3tWvTbvBSQ+akjASn5Ry7oOmRW/I8AtCF32dezojz+TWojgVt7Ja2XdAWgFbRFcamPcxfDMcNBvang7H3ARJZivSKCEkp0C3O50b1dnvwlf3u3UWh54Vb8lKFVEVhaqe6n+bFJ84RrGhCtNfhamvuP3OA90mNkHNKGEkJUHXa91A988vwvdPwo6NcPgVdj8XElEVhYh0ipXQj0MYJZHsLPj2MZg3DiQJjrkRDjkj3lIZRv4RgcMucsrim3/DL6PcOosTbofk1HhLV+KJ1fX0aIxjCpxYyLIYxcHuHfDVfbD8R0gpDz3ugcbHxlsqwygcWp/sjFZ+eS8s+MK1LHrdb65VC0isrqfuxSmIUQykb3C+JDYudH26fR6CtEPiLZVRRmk85OOYxwe3y2RghDhLh50SO+ODjnTrfz69A1ZNgw+vhT7DzLJAAYjV9XSiqn4tIhFHhVR1TNGJtZ8sS3EzrrKATFXtUlxllxo2zIfP74TtfziTHH2GmQVYo/RStxWc8bz7MNq0FD64Bk76F6S1jbdkJZJY01tO8L+nRdhOLWK5ItFdVTuaksgHiyf5hXR/QL0O7gEyJWGUdqrVg9OfgQadnYHLj26EhZGsDhm5Eavr6V7/e2nxiWMUKqow/TWY+rLbb9kHjr/VBveMskP5qtD3Efj+CZj7kZs+++di6HK5TQPPA0HMjNcWkadEZLqITBORJ0WkdnEIF4YCX/jyBxVz2SWTjJ1u0Hrqy25GyFHXQLchpiSMskdyChw3GI65wc3y+2UUjP+n+eLOA6KqsSOIjAe+AUb5oIuAbqras4hlC5ehgaquEpEDgPHA9REs2g4CBgGkpaV1Hj16dHGJlyfS09OpUqVoZ2CU/2sDzRaNpOLONWQlV2Bx04vZWr1NoZcTXpfZq7YUev7FSVpFWLcz3lIUDqWlLtHq0a5B9XznWXXrfJoufpWUzJ3srJjG4qYD+atiWgGkDEZxPPcFpXv37tOide0HURS/quqhOcJmq2q7QpQxMN4ibbqqDo8Wp0uXLjp1amK66Z44cSLdunUrugKWTYavH4Dd6W4covcDzlR4ERBel9xmsCQ6g9tl8ujsWLPFSw6lpS7R6pHrrKfc2LwCvrjbDXKnVoLu/4AmxxUsz1wo8ue+EBCRqIoiSCfdFyJyvogk+e1c4PPCFTE6IlI55J9bRCoDvYFfi6v8EkN2Nkx5yc1s2p3u1kac+UKRKQnDKLHUaOQmdDTr7mxEfXE3/PgfyMqMt2QJS6zpsdvYa+PpJvZ2PSUB6cCtRS2cJw14X9xS/BTgTVX9rJjKLhls3whf3+8swEoSHH45dLzIBusMIxrlKkGPe6FuG/jpPzDzLVg3G3oMNSddEYg166lqcQoSDVVdjPPPbURi5VTX1bRzkzNf0OMeZ6ffMEop+e3m3K/LSgQ6nAcHtHETP9b+Cv+73HVFHXRUIUhaegj0ySkiNUXkCBE5PrQVtWBGLmRlwI/Pw8eDnZKofxic/bIpCcPIK/Xaw99egoaHw19b3IruH56GzN3xlixhyHXES0SuAG4EGgIzgKOAyZitp/ixeblrRWz43XU1dbkUOva3ribDyC8Va7r1FrPehin/hdnvua7cE++GWmZAO8ib5UbgcGCZt/90GLC5KIUyopCd7W7g9y53SqJqPej3NHS6xJSEYRSUpCToeAGc/hxUa+Bsoo0ZBDPfds9eGSbI2+UvVf0LQETKq+o8oFXRimXsx7a18Mlg1yTO2g0tT3LN5QMPzT2tYRjBOaC1e7Zan+qetR+fg3E3wtbV8ZYsbgSZbL1SRGoAHwDjRWQTsKwohTLCyM6GOe/Dz/91q60r1nCrTJvYMJFhFBnlKsEJt7lp5pMehjWz4N2BcPiVcOjfylwLPldFoapn+r9DRWQCUB2w6anFwaalzgnLWr9spOkJzlVpJXNZbhjFwsFd4ZyRriW/8EuY/Izzy338rVC7WbylKzYCLd/03u6Oxa2r+F5VbTpAUZLxF/zyOswcDdmZTjEcc5NTFIZhFC8Va0CPf0KzE+G7x2H9HBhzJbQ7FzoPgNSK8ZawyAliFPAe4FWgNlAHeEVE7i5qwcokqrD0e9fE/WWUUxJtToVzXjUlYRjxpvExrnVxyBmg2W6R3juXODP+uZhCKukEaVFcBHQIG9Aehpsm+0ARylX2+HMJTH4WVk5x+7Wbw7E322C1YSQS5au457JlX/j2UfhjPoy/x61jOvr6UtsdFURRrAYqAH/5/fLAqiKTqKyx40/nM2LOh+4rpXxV6DwQDjkTkpLjLZ1hGJE4oLWzpTZ3rLOxtvoX+N8V0PoU6HwpVC5uTwxFSyxbT0/jxiS2AL95c+MK9AJ+Lh7xSjEZO2HWO24cImOHWzjXtp9zqFKxRrylMwwjN5KSXDdUsxNh2ivw2wfOOdKC8dD+XOhwgZs9VQqI1aII2emeBrwfFj6xyKQpA0h2hlMQM96AnZtd4EFd4chBUKtpXGUzDCMfVKgGx9wIbc+An1+Epd/5XoIPoMOFTpmUcGIZBXw19F9EygEt/e7vqppR1IKVJhoP+Zjy7KZ30lRurTGJWenpAMzXRrySeRK/LWkCk+YCc/dJV2C7+4Zh7KEgPlMCPYs1D4aTHoS1s51F2rW/ut9Zb3NA+Y6w+4gS28IIYuupG27W01KcyfFGIjIgp4c5Iwq70jkneSL9kn6gumynQpbyi9ZnVGZPpmor3Ck1DKPUcGA76PeMm5gyZQRsmEej9WPhzanQ7mw45CzXCilBBBnMfhToraq/A4hIS+AtoHNRClbi2boGfn0P5n3CxclrAFigDVhY5zhuWXQopiAMoxQjAo2OcBZpl/9I+qf/puqujTD1FZjxFrTq65RG9YbxljQQQRRFakhJAKjqfBFJLUKZSi7Z2W72w5z33XoIdYbEZmU35d2sE5ipzRhcKQtTEoZRRhCBg7vye6vrqdeqhlsftXIq/Pa+G8M46Gg3htGgS0KbBQmiKKaJyEvs9XB3EXsHug1w/iAWjHdTXLesdGFJKdCiF7Q7l7uH/x47vWEYpRsRt9ai/mGwcZGzAr1wPCz73m3VGkCb05yxzwQ00RNEUVwNXAvc4Pe/BZ4rMolKClkZsOJnmP+Zu9DZWS68cl13wVufGjaXOn+KotA8eRmGkTjUbgbd7oAjroTfP4E5Y2HrKjfw/fOLbhZkq77Q6EhIKRdvaYFcFIWIJAMzVbU18FjxiJTAZGfD2lnOONjiibBrmwuXJDj4aGh1svu1hXKGYeRGpVpwWH83hXb5ZKc0lv2wt5VRvqoz3dOsB9TrGNeuqZiKQlWzROR3ETlIVZcXl1AJRVaGMzG8ZBIs+cZ1M4Wo2Rha9HbNxcp14iaiYRglmKQkZ0eq8THOUsOCL9y2cRHMHee2ijWdyfMmJ0D9jpBcvMPEQbqeauJWZv8MbA8Fqmq/IpMq3uz40w04Lf/BdS/t3r73WNV60LSbG3+o1dT1PRqGYRQGlWpBh/Pd9udiWPgVLJrguqbmfuS21ErQsIvrvWh4RLGYCwmiKP5Z5FIkAptXwLyP3dznjQv3PVaz8V5tXqdFwisHG9swjMIlLs9UraZwRFM4/ArXulgy0c2m/HOx691Y8s3eeI2OcOMaNRvnv7wYxLL1VAE3kN0cmA2MUNXMIpEiEdi+wZkNBkgp7/oEGx3htHa1+nEVzTCMMowI1GnutsOvcGu0lk+GFT/B6hlOcfy5GOp3Kn5FgVuNnYGb5dQXaAvcWCRSJAIHtnNGvBp2gQPbJ8xsA8MwjH2oVg8OPcttmbth3WxYMQXqdSiyImMpiraq2g5AREZQ2i3GJqfCUVfHWwrDMIzgpJSDBp3dVpTFxDi2x/CfqmZKgvfLGwUnr/2wg9tlMrAAhtYMw4hMoo0zxlIUHURkq/8vQEW/L4CqasmyamUYhmHki6grOFQ1WVWr+a2qqqaE/S9WJSEiffx6joUiMqQ4yzYMwyjrJK4VKo9fHf4sewfULxCRtvGVyjAMo+yQ8IoCOAJYqKqLVXU3MBo4Pc4yGYZhlBlEVeMtQ0xE5Gygj6pe4fcvBo5U1etyxBsEDPK7rcivJb6ipw7wR7yFKCSsLolJaalLaakHlIy6HKyqdSMdCLIyu0Sgqi8CL8ZbjtwQkamq2iXechQGVpfEpLTUpbTUA0p+XUpC19MqoFHYfkMfZhiGYRQDJUFRTAFaiEgTESkHnA+MjbNMhmEYZYaE73ryi/2uAz4HkoGXVfW3OItVEBK+eywPWF0Sk9JSl9JSDyjhdUn4wWzDMAwjvpSErifDMAwjjpiiMAzDMGJiiqKQyM3MiIgcJCITROQXEZklIif78FQReVVEZovIXBG5s/il30/W3OpysIh85esxUUQahh0bICIL/DageCXfn/zWRUQ6ishkEfnNHzuv+KXfT9Z8Xxd/vJqIrBSRZ4pP6sgU8B47SES+8M/LHBFpXKzC56CAdXnE32NzReQpSVTrq6pqWwE33CD7IqApUA6YiTPTHh7nReAa/78tsNT/vxAY7f9XApYCjRO8Lu8CA/z/E4HX/f9awGL/W9P/r1lC69ISaOH/1wfWADVKYl3Cjj8JvAk8E696FEZdgIlAL/+/ClCpJNYFOBr43ueRDEwGusXz2kTbrEVROAQxM6JAyJhidWB1WHhlEUkBKgK7ga3EjyB1aQt87f9PCDt+EjBeVf9U1U3AeKBPMcgcjXzXRVXnq+oC/381sB6IuGq1mCjIdUFEOgNpwBfFIGtu5Lsu3s5biqqOB1DVdFXdUTxiR6Qg10WBCjgFUx5IBdYVucT5wBRF4dAAWBG2v9KHhTMU6C8iK4FPgOt9+HvAdtwX63JguKr+WaTSxiZIXWYCZ/n/ZwJVRaR2wLTFSUHqsgcROQL3MC8qIjmDkO+6iEgS8Chwa5FLGYyCXJeWwGYRGeO7cf/tDYfGi3zXRVUn4xTHGr99rqpzi1jefGGKovi4ABipqg2Bk4HX/QN8BJCF695oAgwWkabxEzMQtwIniMgvwAm4lfJZ8RUp38Ssi4jUA14HLlXV7PiIGJhodfk78ImqroyncHkkWl1SgOP88cNxXT4D4yRjUCLWRUSaA21w1iYaACeKyHHxEzM6Cb/groQQxMzI5fhuGFWdLCIVcIbCLgQ+U9UMYL2IfA90wfXvx4Nc6+K7Ys4CEJEqwN9UdbOIrAK65Ug7sSiFzYV818XvVwM+Bu5S1R+LQ+AYFOS6dAWOE5G/4/r0y4lIuqrGy7dLQeqyEpihqov9sQ+Ao4ARxSB3JApSlyuBH1U13R/7FOgKfFscgucFa1EUDkHMjCwHegCISBtc3+QGH36iD6+Mu+nnFZPckci1LiJSx7eGAO4EXvb/Pwd6i0hNEakJ9PZh8SLfdfHx3wdeU9X3ilHmaOS7Lqp6kaoepKqNcV+3r8VRSUDB7rEpQA0RCY0XnQjMKQaZo1GQuizHtTRSRCQV19pIyK6nuI+ml5YN1500H9ePfZcPux/o5/+3xc1wmAnMAHr78Cq4WRG/4W7420pAXc4GFvg4LwHlw9JeBiz026UltS5Af5zf+BlhW8eSWJcceQwkzrOeCuEe6wXMAmYDI4FyJbEuuJlOL+CUwxzgsXhfl2ibmfAwDMMwYmJdT4ZhGEZMTFEYhmEYMTFFYRiGYcTEFIVhGIYRE1MUhmEYRkxMUeSCiHQTkaPD9m/xFitneYuQB+chr5tEpFIBZGksIheG7XcRkafym1888ed1XLzliIWI/CPH/g95TH+Dtwr6Rj7LT/IWRX8VZ114iog08ceqi8hr3mLpIhF5w69dCd0nv0bIb6SIrBKR8n6/jogsza2sREecRdYu8ZYjkRGRoSKSbxMupihypxvOymOIX4AuqtoeZ6fpkTzkdRPOQmx+aYxbyQ2Aqk5V1RsKkF+e8IYLSw0B6rOPolDVo6NFjMLfcVZOL8qnPOfhTLu0V9V2ODtBm/2xEcBiVW2uqs1w61ZGBigmC7fWJSexyip2Stu9VhSIo1je4WVSUYjIJb5FMFNEXvdhp4nIT+IMjX0pImni7NxfDdwsIjNE5DhVnaB7rVX+iFuynzP/yiLysc//VxE5T0RuwD2IE0Rkgo+XHpbmbBEZ6f+P9F93P4jIYhE520cbhjPFMENEbg7/KvdfDC/7r6vFvrxQ3v8UZy//OxF5K9KXhS/zPyIyVUTmi8ipPnygiIwVka+Br3zdXhaRn/25Cln1/FFEDgnLb6Jv8Rwhzq/DL74+raKcr0h5DhRn/O0zcf4tHglL00dEpvtz/FWsfHKU1U1EvhWRsfgVvSLygYhME+cXYJAPGwZU9Of6jfDr5R/Qf4d9fe/nq0JE/oOzQ/Spv1a1fDmz/LlqH3bdXhdnuuX1HNnUA9aotzGlqitVdZM4G0Gdgf8Li3s/0CHS+c3BE7j7OeeLOGJZEep1uL+OM/15rioiFUTkFX8ufhGR7j5utHsi1vUOcq9VFJHR4lpr7+OsLueUs4+IvBu2301ExolIsr/XQ9fu5lgny8v0TNj+OBHp5v+ni8iD/lz8KCJpPjxNRN734TPF90iI64341W83+bBhInJtWP57vvxF5DZxLbtZInKfD2ss7ll+DfgVaBQpno97l7hn+Tsgt/siNvFe8ReHVZSH4FZI1vH7tfxvTfb6EL8CeNT/HwrcGiWvZ4C7I4T/Dfhv2H51/7s0VK7fTw/7fzbOaCC4L8N3cYq8Lc6MMbjWzbiwNHv2vZw/4MwV1wE24swWH45bVVwBqIpbIbpffXyZn/kyW+CsYFbAreRdGXae/gX09/9r+HNZGbgZuM+H1wN+9/+r4cxCA/QE/hdB9mh5DsTZvKruZVmGs6tTF2exs0mOaxgxnxz17Iaz1tskLCyUviLu4aud8/qE7/vrOx63sjYNZ4qhXoRzuud6A08D9/r/J+LsFYWu2zSgYoT0DX0eM3DWXw/z4f2A9yPEfx84A9fy/DXKNT4bZ0LiUtx9sjRWWTnSl/PX4/DwawsMBl72Ya39+agQ456Idb2D3Gu3hJXXHsjEtfLDZU3xclT2+8/jVtt3xpnCD8Wrkcv7YiBhK9mBcXifETgz4af5/4/g3wXA28BN/n8y7v7tjFtJXhlnjeE34DC/TQrLfw7uHu+N82EjuGdyHHC8v7bZwFE+frR4ofIq+eu0kCjvsSBbWWxRnAi8q6p/AOhek94Ngc9FZDZwG06hREVE+uOM9/07wuHZQC8ReVhcK2RLPuT8QFWzVXUO7mUUhI9VdZev23qf7hjgQ1X9S1W3AR/FSP+OL3MB7oXQ2oePDztPvYEhIjIDZ/CvAnAQ8A7uJQRwLq5bDtxD8q64PvPHiXxeo+UJ8JWqblHVv3AP0cE4e1jfqOoS2OcaxsonnJ9DaT03iMhMXAuxEU5RxuJY4C1VzVLVdcAknELOLc3rXt6vgdrijA4CjFXVnTkTqLP22gpnHygb95XdI5dygvAQ7h7f8/wHLKsVrtUxxafZqqqZvm6jfNg8nEJvSfR7ItZ1CnKvHR9W3iycOY998HJ9BpzmW0+nAB/i7uumIvK0iPShYL5fduNezOCUfWP//0ScYsLfI1tw5+h9Vd2uzgjgGOA4Vf0FOEBE6otIB2CTqq7wde+N6+qejnsWQ/flMt1rpDJavON8eTtUdSv7257LE9YPuJencbZWxvqm5dBoEUWkJ3AXcIKq7sp5XFXni0gnnA2YB0TkK1W9P0JW4fZTKuQ4Fp5vUPeI4WlCJpnzQk57LqH97Tlk+Zuq/p4zsYhs9F0q5+G67MB1j0xQ1TPFdeVNjFBuxDxF5EjyVqeosuVgT338te4JdFXVHSIykf2vRVGzPdoBf399iuvCWodrMTwJdBSRJPVdReL6qjvgXhYxPwBVdYF/+Z4boKyv8lclUNVVUe6JWNc713tNgnsLHQ1cB/wJTPUfSvgX8klennOJPGYTIpN9z2f4vZGh/rOe/D1vId7FKdQDca0RcHV/SFVfCI/on6Gc5yhSvJvyKUtEymKL4mvgHPHOaUSklg+vzl7zwAPC4m/Dddng4x+GM+TVT1XXRypAROoDO1R1FK7F0SlSXsA6EWnjH/IzA8ieM30Qvsd9VVUQZ+L41BhxzxE3+6UZrn890gv3c+B68U+rPx8h3gZux3W1hb7yws/rwCjlxsozEj8Cx8veGUCha5jXfELybfJKojWutRIiQ5xVz5x8C5zn+7vr4r5wf86lnG+Bi7xc3YA//JdeVESkk7+XQoqgPe5rciHuC/LusOh341pfy3ORI8SDhDkyilZWjjS/A/VE5HAfr6r/Wg+vW0vcV3/o3ol0TwS9TtHifYOf1CEih3pZIzEJ9+xdiVMaiEgdIElV/4c7Z52ipA2xFK+URaQRzn9MbnwFXOPLSxaR6rhzdIaIVBJnJfpM9poTfxtndfZsnNII1f0y/8wiIg1E5IAIZUWL940vr6KIVAVOCyB3VMqcolDV33APySTf3fCYPzQU10UyDfgjLMlHwJniB7NxL/4qPu4McYOiOWkH/Oy/2u4FHvDhLwKfiR/MBobgmq4/4Dxc5cYsnMOTmZLLIFxYfafgmp2zcF+Ls4FoXWHLcS+8T4GrfXdPTv4PN/YxS0R+Y98B1fdwN/w7YWGPAA+Jc9oS7YsrVp6R6rQBGASM8dcw9BWWp3w8nwEpIjIXN1kg3O/Eiz6vnNNb38edz5m4D4/bVXVtLuUMBTqLyCxfzoDY0QE4APjId9vNwn3dhgZWL8OZt14kIhtwCu7qsLStRGRl2HZOeMb+OZgesKxQmt24lsHT/ryPx31hPwckieu2fRsYGNbSjnRPBL1O0eI9D1Tx1+x+XLfPfqhqFu756sveLqIGwET/bI7CdbUhIleLyNURsvkeWILr9nyKfc9ZNG4EuvvzMQ3nQ3s6bozoZ+An4CXf7RS6FlWBVaq6xod9gfNvPtnn8x4RPhKjxfPlvY27Rz/FmUPPN2Y9tgwgIlVUNV3cGo5vgEH+RgqPMxI3uJwIvheMPCBuptPHwA2q+km85TFKHzZGUTZ4UZxT+grAqzmVhFGy8X34zeMth1F6sRaFYRiGEZMyN0ZhGIZh5A1TFIZhGEZMTFEYhmEYMTFFYRiGYcTEFIVhGIYRk/8H3zWlekENJoUAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "stunting_prevalence_ratio.query(\"stunting_state == 'cat2'\").value.hist(bins=20, density=True)\n",
+    "plt.xlabel(\"cat2 stunting prevalence ratio for SQLNS covered vs. uncovered\")\n",
+    "plt.ylabel(\"Probability density over 288 combinations\\nof (year, sex, age, draw)\")\n",
+    "plt.title(\"Moderate stuntining prevalence ratio histogram\")\n",
+    "normal_dist = normal_dist_from_mean_lower_upper(0.93, 0.88, 0.98, scale_factor=1) # 0.93 (95% CI 0.88 to 0.98)\n",
+    "plot_pdf(normal_dist, f'N({normal_dist.mean()}, {normal_dist.std():.2}^2) pdf')\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "03cc42a6",
    "metadata": {},
    "outputs": [
     {
@@ -1907,7 +2506,7 @@
        "Name: value, dtype: float64"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1918,8 +2517,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "id": "e2711d90",
+   "execution_count": 30,
+   "id": "57f28ab8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYoAAAEWCAYAAAB42tAoAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAzTklEQVR4nO3dd7gdVb3/8feHHkiowUgPKIhIECUKKOAJKheQIlwElSLFy8UCiHC9YCM/BcECV4qoKL0FaUpRIYIRgVASiqEjEJRepCQ0Cfn8/lhrk8lm7zlz2t77nPN9Pc9+zp6ZNbO+U85eM2vNrJFtQgghhGYWaHcAIYQQOlsUFCGEEEpFQRFCCKFUFBQhhBBKRUERQgihVBQUIYQQSkVB0cEk/ULSd/L3LkmPlqQ9XdIRrYuuGkmbSrqvv9MOVpL2lHRdu+Pob5JmS1qjF/NNlHR2yfS7JHX1JbbQd1FQtIGkmZL+LWl03fjbJFnSWADb+9n+/gDHYknvHqjl2f6r7fdUmbcnaUP7SJoi6YvFcbZH2n6ov/Oy/T7bU7qJZ2w+7hbq7/xDEgVF+zwMfK42IGkcsHj7wgk1w/kHZzivezOxTaKgaKezgD0Kw18AziwmKKtOkvQBSbdKmiXpfGCxZhlJerekv0h6UdKzOT2Srs1J7shVB7s0qhopXiXkmH4m6Yqc902S3lWyvPmqzPLV1CGS/pbjOV/SYnla5bR5+jckPSHpcUlfLLs6ymfBR0m6WdJLkn4nadk8rXZGuo+kfwDX5PF7S7pH0vOSrpS0Wh7/c0k/qVv+7yR9PX8/VNKDefvcLWmHkn2ztqTJkv4l6T5JOxemNd3Wefr7CvM+JembefwChRiek/Sb2ro2yL9L0qOS/lfSk8BpkpaRdLmkZ/K6Xy5p5Zz+SGBT4MS8j09scIwsJenMPP8jkr4tqey3ZpGcfpZSVdP4QnwzJX0if/+wpGl5/z0l6dicrHbcvZBj2jhvg2/n/J/Oy1+qsNw98rTnJH2nLp+Jki6UdLakl4A9c95TJb2Qj7kTJS1SWJ4lfVnSA3k9vi/pXZJuyPH+pph+0LEdnxZ/gJnAJ4D7gPcCCwKPAqsBBsbmdKcDR+TvXcCj+fsiwCPAQcDCwE7AG7W0DfI7D/gW6cRgMWCTwjQD7y4M7wlcVzf/W2lyTM8BHwYWAs4BJpUs7624C+t+M7AisCxwD7BfL9JuCTwJvI90JXZ2fd516zAFeAxYF1gCuAg4O08bm+c9M08bAWwP/D3vn4WAbwM35PSbAf8ElIeXAV4FVszDn8kxLwDsArwMrFC/fXNe/wT2ynl8AHgWWKe7bQ2MAp4ADs77dBSwYZ52IHAjsDKwKPBL4Lwm26ULmAP8MKcdASwH/GferqOAC4Df1m3LL5YcI2cCv8vzjgXuB/Zpkv9E4DVga9L/wVHAjfX/K/n7VGD3/H0ksFHd/luoMN/eef+tkdNeDJyVp60DzAY2If0v/YT0//OJQkxvAJ/O+3AEsAGwUd4PY0nH4tfq1v93wJKkY/J14Oqc/1LA3cAX2v3b09tPXFG0V+2q4pOkA++xivNtRCogfmr7DdsXAreUpH+DVAitaPs1231tTL3E9s2255B+vNbv4fzH237c9r+Ay7qZv1nanYHTbN9l+xXSP3d3zrJ9p+2Xge8AO0tasDB9ou2Xbb8K7AccZfuevJ4/ANbPVxV/Jf0wbJrn2wmYavtxANsX5Jjn2j4feID0Y19vG2Cm7dNsz7F9G6kA+0whTbNtvQ3wpO1j8j6dZfumPG0/4Fu2H7X9et42O6l5Fcpc4HDbr9t+1fZzti+y/YrtWcCRwMe62bYA5O35WeCwHNNM4Bhg95LZrrP9e9tvkv4n3t8k3RvAuyWNtj3b9o0ly9wVONb2Q7ZnA4cBn83bYCfgMtvX2f438F3S/iyaavu3eR++anu67RvzfppJKnzrt8mPbL9k+y7gTuCqnP+LwB9IJwKDUhQU7XUW8HnSWeaZ5UnnsyLwmPOpTPZISfpvAAJuzpf2e/c00DpPFr6/QjpjG6j5m6VdkXQ2XlP83kwxzSOkwnZ0k+mrAcflqoYXgH+RtuFKebtPYl4b0+dJP+LAW9UatxfmXbcun2IeG9bS5bS7Au8spGm2/qsADzZZz9WASwrLvAd4ExjTJP0ztl8rxL+4pF/mqpmXSFU7S9cVqs2MJm3X4vH4CLBSyTz167hYk0JtH2At4F5Jt0japmSZKzaIYSHSNpjv2MknGs/VzT/f8SRprVwF92TeJj/g7fv0qcL3VxsM9/T/pGNEQdFGth8hNWpvTbo0ruoJYCVJKoxbtSSfJ23/l+0Vgf8GTlLzO51eptCoLumdTdK12xOkqpWaVSrMU0yzKukM9dnCuGLB+0/gv20vXfiMsH1Dnn4e6Sx9NWBD0pUAefhXwFeB5WwvTTq7LO6rYh5/qctjpO0vVViXf5KqNZpN26puuYvZbnbFWn82fTDwHlJV1pKkqjYK61DW5fSzzLuCrVmV6lfLTdl+wPbngHeQqsoulLREk3gebxDDHNKP93zHjqRaddt82dUN/xy4F1gzb5Nv0nifDklRULTfPsDmuTqkqqmkg/4ASQtL2pHGVRsASPpMrTESeJ70TzA3Dz/F/D84dwDvk7S+UsPxxB7E1Wh5A+U3wF6S3itpcVJVUnd2k7ROTv894MJc3dHIL4DDJL0P3mqgfatKKFcTPQv8GrjS9gt5Uu2H65k8316kK4pGLgfWkrR73o8LS/qQpPdWWJfLgRUkfU3SopJGSdqwEPuRmtf4vryk7Ssss2YU6Qz4BaVG8MPrpjfdx3l7/ibnPyrH8HVSG1KfSNpN0vK25wIv5NFzSdt6bl1M5wEHSVpd0kjSFcD5uQrvQmBbSR/JDcwT6f5HfxTwEjBb0tpAlcJ8yIiCos1sP2h7Wg/n+TewI6nK6l+kBtOyK5IPATdJmg1cChzoefe8TwTOyNUUO9u+n/Qj+idS3XpP2zPmW14P563M9h+A44E/kxota/XVr5fMdhapgfhJUgPwASXLv4R01jopVzXcCWxVl+xc0k0J5xbmu5tUJz+V9IM6Dri+SR6zgC1IdfqP57hqjcql8ryfBLbN8z0ATMiTjyPt56skzSJtmw0bLaeJn5IacJ/N8/6xbvpxpKup5yUd32D+/UlXpg+Rjp9zgVN7kH8zWwJ35eP4OOCzuf3gFVI7yvX5uNso53cWqdrsYVKD+f4AuQ1hf1L14ROkhu2nKT92DiFVMc4iXTGe3w/rM2jU7toIYVDLZ+F3Aovms8b66VNIdzn9utWxhc6WrzheIFUrPdzmcDpSXFGEQUvSDrnaZRnSmfhljQqJEOpJ2jY32i9Buj12BulW3NBAFBRhMPtvUpXBg6S7eoZVvXHok+1J1X2PA2uSqrGieqWJqHoKIYRQKq4oQgghlBqSnV2NHj3aY8eObVl+L7/8MksssUTL8us0sf6x/rH+g3/9p0+f/qzt5RtNG5IFxdixY5k2rUd3nPbJlClT6Orqall+nSbWP9Y/1r+r3WH0maSmvTt0TNWTpFOVenm8szDux5LuVeo99BJJS7cxxBBCGJY6pqAgPQi1Zd24ycC6ttcj9UB5WKuDCiGE4a5jCgrb15KeMi6Ou6pwX3yt2+QQQggt1FG3xyq9AvRy22/rG0fSZaS+Whr2GSNpX2BfgDFjxmwwadKkgQx1PrNnz2bkyEHbMWSfxfrH+sf6D/71nzBhwnTb4xtN67YxW9JHgdttvyxpN+CDwHG559OWkPQtUid45zRLY/tk4GSA8ePHu5WNS0OlMau3Yv1j/WP9u9odxoCqUvX0c+AVSe8ndT/8ID17d0KfSNqT9JKWXePJyRBCaL0qBcWc/AO9PXCi7Z+RutwdcJK2JL10Z7vcQ2QIIYQWq1JQzJJ0GLAbcIXSS9IX7u9AJJ1H6pr5PUove98HOJFUKE3Obwz7RX/nG0IIoVyVB+52IfXDvo/tJyWtCvy4vwPJb66qd0p/5xNCCKFnui0obD8JHFsY/gctbKMIIbTf2EOvaDrt4HFz2LNk+syjPzUQIYUW6rbqSdKOkh6Q9KKklyTNym/8CiGEMAxUqXr6EbCt7XsGOpgQQgidp0pj9lNRSIQQwvBV5YpimqTzgd9SePm47YsHKqgQQgido0pBsSTwCrBFYZyBKChCCGEYqHLX016tCCSEEEJnqnLX08r5XRBP589FkqIX1xBCGCaqNGafBlwKrJg/l+VxIYQQhoEqBcXytk+zPSd/Tgcavlc1hBDC0FOlMfu53L34eXn4c8BzAxdSCGEoKXuquzvxVHdnqHJFsTewM/Ak8ASwExAN3CGEMExUuevpEWC7FsQSQgihAzUtKCR9w/aPJJ1Aem5iPrYPGNDIQgghdISyK4patx3TWhFICCGEztS0oLB9Wf76iu0LitMkfWZAowohhNAxqjRmH1ZxXAghhCGorI1iK2BrYCVJxxcmLQnMGejAQgghdIayNorHSe0T2wHTC+NnAQcNZFAhhBA6R1kbxR3AHZLOtf1GC2MKIYTQQao8mT1W0lHAOsBitZG21xiwqEIIIXSMqp0C/pzULjEBOBM4eyCDCiGE0DmqFBQjbF8NyPYjticC0QFLCCEME1Wqnl6XtADwgKSvAo8BIwc2rBBCCJ2iyhXFgcDiwAHABsDuwBcGMqgQQgido0qngLfkr7OJXmNDCGHY6bagkLQW8D/AasX0tjcfwLhCCCF0iCptFBcAvwB+Bbw5UIFIOhXYBnja9rp53LLA+cBYYCaws+3nByqGEEIIb1eljWKO7Z/bvtn29NpnAGI5HdiybtyhwNW21wSuzsMhhBBaqEpBcZmkL0taQdKytU9/B2L7WuBfdaO3B87I388APt3f+YYQQign+23vJJo/gfRwg9EeiCezJY0FLi9UPb1ge+n8XcDzteEG8+4L7AswZsyYDSZNmtTf4TU1e/ZsRo4cvncMx/oP/fWf8diLTaeNGQFPvTow+Y5baamBWXA/Gir7f8KECdNtj280rcpdT6v3f0g9Z9uSmpZqtk8GTgYYP368u7q6WhUaU6ZMoZX5dZpY/6G//nseekXTaQePm8MxM6o0d/bczF27BmS5/Wk47P+ybsY3t32NpB0bTbd98cCF9ZanJK1g+wlJKwBPtyDPEEIIBWWnAR8DrgG2bTDNQCsKiktJD/cdnf/+rgV5hhBCKCjrZvzw/LclD9lJOg/oAkZLehQ4nFRA/EbSPsAjwM6tiCWEEMI8VR64W470o70J6UriOuB7tp/rz0Bsf67JpI/3Zz4hhBB6psrtsZOAZ4D/BHbK388fyKBCCCF0jiq3Kqxg+/uF4SMk7TJQAYUQQugsVa4orpL0WUkL5M/OwJUDHVgIIYTOUHZ77CxSm4SArzHvrXYLkHqSPaRk3mWAFYFXgZm25/ZTvCGEEFqs7K6nUT1ZkKSlgK8AnwMWIbVlLAaMkXQjcJLtP/ch1hBCCG1Q6XFKSeuRenAtdjNe/xzFhaT3aW9q+4W6+TcAdpe0hu1T+hJwCCGE1qpye+ypwHrAXUCtCultD9zZ/mSzZeTeZgeix9kQQggDrMoVxUa216m6QElnA38B/mr73l5HFkIIoSNUuetpqqTKBQVwCrACcIKkhyRdJOnA3oUXQgih3apcUZxJKiyeBF4n3QVl2+s1Smz7z5KuBT4ETAD2A94HHNc/IYcQQmilKgXFKcDuwAzmtVE0JelqYAlgKvBX4EO2o9fXEEIYpKoUFM/YvrQHy/wbsAGwLvAi8IKkqbYH6NUmIYQQBlKVguI2SecCl5GqnoDm76OwfRCApFHAnsBpwDuBRfsabAghhNarUlCMIBUQWxTGNX0fhaSvApuSripmAqeSqqBCCCEMQlVehdrT91EsBhwLTLc9p1dRhRBC6Bjd3h4raWVJl0h6On8ukrRys/S2f2L7JmBZSavWPv0adQghhJap8hzFaaRXkq6YP5flcQ1J2lbSA8DDpAfvZgJ/6HOkIYQQ2qJKQbG87dNsz8mf04HlS9IfAWwE3G97ddIb6m7se6ghhBDaoUpB8Zyk3SQtmD+7AWWvQX0jvyZ1AUkL5B5jx/dLtCGEEFquyl1PewMnAP9HutvpBqCsgfsFSSOBa4FzJD0NvNzXQEMIIbRHlbueHgG268Eytye9sOggYFdgKeB7vYouhBBC21W56+kMSUsXhpfJXY83SrsgcLntubk94wzbx+eqqBBCCINQlTaK9YovIrL9PPCBRgltvwnMzW+7CyGEMARUaaNYQNIyuYBA0rLdzDcbmCFpMoW2CdsH9CnSEEIIbVGloDiG1M34BXn4M8CRJekvpkn3HiGEEAafKo3ZZ0qaBmyeR+1o++6S9Gf0V3AhhBDar8oVBblgaFo4AEiaQbp9ttkyGr7oqApJBwFfzMufAexl+7XeLi+EEEJ1lQqKirbJf7+S/56V/+5GSQHSHUkrAQcA69h+VdJvgM8Cp/d2mSGEEKrrt4IiP2+BpE/aLt4V9b+SbgUO7cPiFwJGSHoDWBx4vA/LCiGE0AOym5/sS1qo1lV4ftp6beAh2/8qmed24Cu2r8/DHwFOsr1+r4OUDiQ1oL8KXGV71wZp9gX2BRgzZswGkyZN6m12PTZ79mxGjhzZsvw6Taz/0F//GY+92HTamBHw1AC9v3LcSp1/p/1Q2f8TJkyYbrthd0tNCwpJe5LueHoOOBD4GalH2LWAb9g+r8l8G5BeVlTbwy8Ae9u+tTfBS1oGuAjYJS/rAuBC22c3m2f8+PGeNm1ab7LrlSlTptDV1dWy/DpNrP/QX/+xh17RdNrB4+ZwzIz+rMWeZ+bRnxqQ5fanobL/JTUtKMr27sHAe4BRwB3AB2w/KGkMMBloWFDYng68v/bQne3mpyLVfAJ42PYzAJIuBj4CNC0oQggh9J+yguJN288Cz0qabftBANtPSep2wf1QQNT8A9hI0uKkqqePA627XAghhGGurKD4h6SjSFcU90o6hvQg3SeAJ1oRHIDtmyRdCNwKzAFuA05uVf4hhDDclfX1tBvwEvAoqffYqcBhwBhgzwGPrMD24bbXtr2u7d1tv97K/EMIYThrekVh+yXgqMKoC/OnRySNBx63Hbe0hhDCINT0ikLSeEl/lnS2pFUkTZb0gqRbJDXsPbaJ/YErJJ3f93BDCCG0WlkbxUnA4cDSpLfaHWT7k5I+nqdtXCUD218AkDSqb6GGEEJoh7I2ioVt/yE/L2HbF5K+XA0s1mwmJbtJ+m4eXlXSh23P6tfIQwghtERZQfGapC0kfQawpE8DSPoY8GbJfLWrjc/l4Vmkh/VCCCEMQmVVT/sBPwLmAv8BfEnS6cBj5K4ymtjQ9gcl3QbpjXiSFumneEMIIbRY2V1Pd5AKiJoD86c7b+R3ZxtA0vKkwiaEEMIgVPrObElrS/p47hCwOH7LktmOBy4B3iHpSOA64Ad9jjSEEEJblN0eewDwO9LtrXdK2r4wuekPv+1zgG+QnsF4Avi07QuapQ8hhNDZytoo/gvYwPZsSWOBCyWNtX0c0LSzJ0nLAk9T6DRQ0sK23+inmEMIIbRQWUGxgO3ZALZnSuoiFRarUVJQkPpkWgV4PqdbGnhS0lPAf+XeZUMIIQwSZW0UT0lavzaQC41tgNHAuJL5JgNb2x5tezlgK+By4MukW2dDCCEMImUFxR7Ak8URtufY3gPYrGS+jWxfWZjnKmBj2zcCi/Yl2BBCCK1XdnvsoyXTri9Z5hOS/heovYt0F9LVyYLEbbIhhDDolN4e20ufB1YGfps/q+ZxCwI7D0B+IYQQBlC/v+g2vxVv/yaT/97f+YUQQhhYpQVFri76k+0JVReYn8T+BvA+Cp0H2t68t0GGEEJon9KqJ9tvAnMlLdWDZZ4D3AusDvw/YCZwS28DDCGE0F5Vqp5mAzMkTQZero20fUCT9MvZPkXSgbb/AvxFUhQUIYQwSFUpKC7On6pqT2A/IelTwOPAsj0NLIQQQmfotqCwfYakEcCqtu+rsMwjclXVwcAJwJLAQX0LM4QQQrt0W1BI2hb4CbAIsHp+Wvt7trdrlN725fnri0DlRvAQQgidqUrV00Tgw8AUANu3S1pjAGMKIQQAxh56Ra/nnXn0p/oxkuGtygN3b9h+sW5cPGEdQgjDRJUrirskfR5YUNKawAHADQMbVgghhE5R5Ypif9LDc68D55LaHr5WNQNJ20vasFfRhRBCaLsqVxRr2/4W8K1e5rEhME7SQra36s0CJC0N/BpYl/Qu7r1tT+1lPCGEEHqgSkFxjKR3AhcC59u+sycZ2P5mryKb33HAH23vJGkRYPF+WGYIIYQKuq16yv08TQCeAX4paYakbzdLL+n7khYqDC8p6bTeBpifydgMOCXH82/bL/R2eSGEEHqmUjfjtp+0fTywH3A78N2S5AsBN0laT9InSf089eX1p6uTCqnTJN0m6deSlujD8kIIIfSAbJcnkN5LevnQTsCzwPnARbafLpnn46TXnz4PbGa7192LSxoP3Ah81PZNko4DXrL9nbp0+wL7AowZM2aDSZMmvX1hA2T27NmMHDmyZfl1mlj/ob/+Mx6rv0N+njEj4KlXWxhMReNW6klfpr03VPb/hAkTptse32halYJiKultdRfYfry7zCRtBvwcOJv0bu1lgH2qzNtkee8EbrQ9Ng9vChxqu+nTNOPHj/e0adN6k12vTJkyha6urpbl12li/Yf++pc9+HbwuDkcM6PfX23TZ6164G6o7H9JTQuKKn09bZwbkNeStCxwn+03Smb5CfAZ23fnzHcErgHW7nnoqdpL0j8lvSf3NfVx4O7eLCuEEELPVenr6WPAmaT3SghYRdIXbF/bZJaN83ssALB9saS/9DHO/YFzcoH1ELBXH5cXQgihoirXi8cCW9R6jpW0FnAesEGT9O+S9HNgjO11Ja0HbAcc0dsgbd8ONLwkCiGEMLCq3PW0cLF7cdv3AwuXpP8VcBj5vRS2/wZ8ti9BhhBCaJ8qVxTTJP2a1DgNsCtQ1lK8uO2bJRXHzellfCGEENqsSkHxJeArpM4AAf4KnFSS/llJ7yJ1tYGknYAn+hJkCCGE9qly19PrpHaKYysu8yvAycDakh4DHgZ263WEIYQQ2qrfb362/RDwifz09AK2Z/V3HiGEEFqnUhcePSHpQElLAq8A/yfpVklb9Hc+IYQQWqPbgkLSuB4uc2/bLwFbAMsBuwNH9yK2EEIIHaDKFcVJkm6W9OXck2t3arc7bQ2cafuuwrgQQgiDTJVuxjcl3RK7CjBd0rm5V9hmpku6ilRQXClpFPGO7RBCGLQqNWbbfiC/g2IacDzwAaUHJb5p++K65PsA6wMP2X5F0nJElxshhDBoVenraT3SD/2ngMnAtrZvlbQiMBWYr6CwPRe4tTD8HPBcfwYdQgihdapcUZxAel/1N22/1eu87cfL3nQXQghhaKjSmH2J7bOKhYSkAwFsnzVgkYUQQugIVa4o9gB+WjduT+C4/g4mtEfZS2mqOHjcHPbsxTJa9WKZEELfNC0oJH0O+DywuqRLC5NGAf+qmoGke/LXn9k+sVdRhhBCaJuyK4obSJ35jQaOKYyfBfytaga235vvfNqoVxGGEEJoq6YFhe1HgEeAjasuTNKCwJ9sT6hb1nNA3+o3QgghtEXTxmxJ1+W/syS9VPjMkvRSo3nyK1DnVnyCO4QQwiBQdkWxSf47qofLnA3MkDQZeLmwvAOazxKGo740okdDeM/09YaFMLxVeeDuXcCjtl+X1AWsR+rD6YUms1xM3UN4IYQQBq8qt8deBIyX9G7SC4l+B5xL6svpbWyf0X/hhRBCaLcqBcVc23Mk7QCcYPsESbc1SyxpTeAoYB1gsdp422v0OdoQQggtV+XJ7DfyMxVfAC7P4xYuSX8a8HNgDjABOBM4uy9BhhBCaJ8qVxR7AfsBR9p+WNLqQFnXHSNsXy1J+RbbiZKmA9/th3hDGNSiAT8MRt0WFLbvBg4oDD8M/LBkltclLQA8IOmrwGPAyL4GGkIIoT2qvAr1o5ImS7pf0kOSHpb0UMksBwKLkwqXDYDdSNVWIYQQBqEqVU+nAAcB04E3u0ts+xYASXNtxwuLQghhkKvSmP2i7T/Yftr2c7VPs8SSNpZ0N3BvHn6/pJP6GqikBSXdJuny7lOHEELoL1WuKP4s6cekh+her420fWuT9D8F/gO4NKe7Q9JmfYwTUpXWPcCS/bCsISWeug0hDKQqBcWG+e/4wjgDmzebwfY/0yu139JtlVUZSSuTXsV6JPD1viwrhBBCz8h2/y5QuhA4FjiRVMgcCIy3/dk+LvMo0rswDrG9TYM0+wL7AowZM2aDSZMm9Ta7Hps9ezYjR7bvxq4Zj73YtrwBxoyAp17tPl1/GrdS5/Q72ZP935d91Zd1HshjpB37v4pWHSPt/v/vLxMmTJhue3yjaVX6ehoD/ABY0fZWktYBNrZ9SpNZ9iO9/W4l0q2xVwFf6VXkKf9tgKdtT899TTVk+2RSFyOMHz/eXV1Nk/a7KVOm0Mr86vXm7XL96eBxczhmRpWL0/4zc9euluZXpif7vy/7qi/rPJDHSDv2fxWtOkba/f/fClUas08HrgRWzMP3A18rSW/bu9oeY/sdtncra/yu4KPAdpJmApOAzSXFk94hhNAiVU4DRtv+jaTDAHK/T2VtDjdKuh04Ffij+1i3Zfsw4DCAfEVxiO3d+rLMEPrzBoDevjM8dK6eHB+N9v9Qe4q+yhXFy/lVpgaQtBFQVuG5FqkKaA/S09k/kLRWnyMNIYTQFlWuKL5OutX1XZKuB5YHdmqWOF9BTAYmS5pA6hDwy5LuAA61PbW3wdqeAkzp7fwhhBB6rkpfT7dK+hjwHkDAfbbfaJY+X33sBuwOPAXsTypo1gcuAFbve9ghhBBapWlBIWnHJpPWkoTtZm+xm0rqXfbTth8tjJ8m6Re9jDOEEEKblF1RbJv/vgP4CHBNHp4A3EDz152+p1kDtu2yXmdDCCF0oKYFRa1DP0lXAevYfiIPr0C6ZXY+kn4FHG97RoNpSwC7AK/bPqd/Qg8hhNAKVRqzV6kVEtlTwKoN0v0M+I6kccCdwDOkV6GuSeqf6VQgCokQQhhkqhQUV0u6EjgvD+8C/Kk+ke3bgZ0ljST1C7UC8Cpwj+37+ifcEEIIrVblrqevStoBqPUAe7LtS0rSzyZuYQ0hhCGjUgctuWBoWjiEEEIYuqo8mR1CCGEY67eCQtJZ+e+B/bXMEEII7ddtQSFpW0lVCpQNJK0I7C1pGUnLFj99DzWEEEI7VGmj2AX4qaSLgFNt39sk3S+Aq4E1gOmk7j5qnMeHEEIYZLq9Ushden8AeBA4XdJUSftKGlWX7njb7yUVJmvYXr3wiUIihBAGqap3Pb2UX0c6gvTSoh2A/5F0vO0T6tJ+SdL7gU3zqGtt/60fYw6hX98nMVgMx3Xui9he/adKG8X2ki4hPRuxMPBh21sB7wcObpD+ANIT2O/In3Mk7d+fQYcQQmidKlcUOwL/Z/va4kjbr0jap0H6LwIb2n4ZQNIPST3KntAgbQghhA5X5W6mJ+sLifzjj+2rG6QXUHxV6pvM37AdQghhEKlSUHyywbitStKfBtwkaaKkicCNwCm9iC2EEEIHKHtx0ZeAL5NegVpsjB4FXN9sPtvHSpoCbJJH7WX7tn6INYQQQhuUtVGcC/wBOAo4tDB+lu1/lS3U9q3ArX0PL4QQQruVFRS2PVPSV+onSFq2u8IihBDC0NDdFcU2pKesTTxpHUIIw1LZq1C3yX9Xb104IYQQOk1ZY/YHy2bM7RChn8RTpCGETlVW9XRMyTQDm/dzLCGEEDpQWdXThFYGEkIIoTOVVT1tbvsaSTs2mm774oELa744VgHOBMaQrmROtn1cK/IOIYRQXvX0MeAaYNsG0wy0pKAA5gAH2741d20+XdJk23e3KP8QQhjWyqqeDs9/92pdOA3jeAJ4In+fJekeYCUgCooQQmgB2S5PIC0HHE7qksPAdcD3bD838OG9LZaxwLXAurZfqpu2L7AvwJgxYzaYNGlSy+KaPXs2I0eO7NMyZjz2Yj9F03pjRsBTr7Y7ivaJ9Y/1r1//cSst1evl9eW3oC/5TpgwYbrt8Y2mVSkoJpN+nM/Oo3YFumx/otcR9YKkkcBfgCO7ax8ZP368p02b1prAgClTptDV1dWnZQzm22MPHjeHY2ZUegfWkBTrH+tfv/4zj/5Ur5fXl9+CvuQrqWlBUWXvrmD7+4XhIyTt0utoekHSwsBFwDmtakQPIYSQVOlm/CpJn5W0QP7sDFw50IHVSBKpm/J7bB/bqnxDCCEkZbfHzmJeH09fY17V0wLAbOCQgQ4u+yiwOzBD0u153Ddt/75F+YcQwrBWdtfTqFYG0ozt64g35IUQQttUaoGStAywJrBYbVz961FDCCEMTd0WFJK+CBwIrAzcDmwETCX6egohhGGhSmP2gcCHgEdy/08fAF4YyKBCCCF0jioFxWu2XwOQtKjte4H3DGxYIYQQOkWVNopHJS0N/BaYLOl54JGBDGqwGswPzYUQQjPdFhS2d8hfJ0r6M7AU8McBjSqEEELHqHrX0weZ19fT9bb/PaBRhRBC6BjdtlFI+i5wBrAcMBo4TdK3BzqwEEIInaHKFcWuwPsLDdpHk26TPWIA4wohhNAhqtz19DiFB+2ARYHHBiacEEIInaasr6cTSG0SLwJ35e7GDXwSuLk14YUQQmi3sqqn2gsdpgOXFMZPGbBoQgghdJyyTgHPqH2XtAiwVh68z/YbAx1YCCGEzlClr6cu0l1PM0m9uK4i6QvRKWAIIQwPVe56OgbYwvZ9AJLWAs4DNhjIwEIIYbAaar00VLnraeFaIQFg+35g4YELKYQQQiepckUxXdKvmfeGu12Z19AdQghhiKtSUOwHfAU4IA//FThpwCIKIYTQUUoLCkkLAnfYXhs4tjUhhRBC6CSlbRS23wTuk7Rqi+IJIYTQYapUPS1DejL7ZuDl2kjb2w1YVCGEEDpGlYLiOwMeRQghhI5V1tfTYqSG7HcDM4BTbM9pVWAhhBA6Q1kbxRnAeFIhsRXpwbsQQgjDTFnV0zq2xwFIOoXoMTaEEIalsoLirY7/bM+R1IJw2q83j94fPG4Oew6xR/ZDCKGmrKB4v6SX8ncBI/KwANtecsCjCyGE0HZN2yhsL2h7yfwZZXuhwveWFhKStpR0n6S/Szq0lXmHEMJwV6VTwLbKT4f/jNSgvg7wOUnrtDeqEEIYPjq+oAA+DPzd9kO2/w1MArZvc0whhDBsyHa7YyglaSdgS9tfzMO7Axva/mpdun2BffPge4D7aJ3RwLMtzK/TxPrH+sf6D36r2V6+0YQqT2YPCrZPBk5uR96Sptke3468O0Gsf6x/rP/QXv/BUPX0GLBKYXjlPC6EEEILDIaC4hZgTUmrS1oE+CxwaZtjCiGEYaPjq57yw35fBa4EFgROtX1Xm8Oq15Yqrw4S6z+8xfoPcR3fmB1CCKG9BkPVUwghhDaKgiKEEEKpKChKSDpV0tOS7mwyXZKOz12L/E3SBwvT3pR0e/4Mysb3Cuu/tqSpkl6XdEjdtEHf7Uof13+mpBl5/09rTcT9q8L675qP+xmSbpD0/sK04bD/y9Z/0O//+diOT5MPsBnwQeDOJtO3Bv5A6ihxI+CmwrTZ7Y6/Bev/DuBDwJHAIYXxCwIPAmsAiwB3kLqtb/s6tWL987SZwOh2r8MAr/9HgGXy961qx/8w2v8N13+o7P/iJ64oSti+FvhXSZLtgTOd3AgsLWmF1kQ38Lpbf9tP276FQpf02ZDodqUP6z8kVFj/G2w/nwdvJD3jBMNn/zdb/yEnCoq+WQn4Z2H40TwOYDFJ0yTdKOnTLY+svcq2y3Bh4CpJ03P3MkPdPqSraxie+7+4/jDE9n/HP0cxiK1m+zFJawDXSJph+8F2BxVaZpO8/98BTJZ0bz5DHXIkTSD9UG7S7ljaocn6D6n9H1cUfdO0exHbtb8PAVOAD7Q6uDYa9t2uFPb/08AlpOqYIUfSesCvge1tP5dHD5v932T9h9z+j4Kiby4F9sh3P20EvGj7CUnLSFoUQNJo4KPA3e0MtMWGdbcrkpaQNKr2HdgCaHjnzGAmaVXgYmB32/cXJg2L/d9s/Yfi/o+qpxKSzgO6gNGSHgUOBxYGsP0L4PekO5/+DrwC7JVnfS/wS0lzSYXx0bYHXUHR3fpLeicwDVgSmCvpa6S7W14aBN2udKu360/qdvoSpffMLwSca/uPLV+BPqpw/H8XWA44Ka/rHNvjPTi63elWb9cfGMMQ2P9F0YVHCCGEUlH1FEIIoVQUFCGEEEpFQRFCCKFUFBQhhBBKRUERQgihVBQU3ZDUJekjheH9Cr1CXidpnR4s65t9jGV9SVsXhrcbxD1z7inpxHbH0YykpSV9uTC8oqQLe7iMH0u6S9KPexnD4pLOycfbnfl4G5mnrSzpd5IekPSQpBMLz+50Sbq8wfKmFHsylTRe0pTu8up0uafW0e2Oo5NJOl3STr2dPwqK7nWReomsOdf2ONvrAz8Cju3BsvpUUADrk57bAMD2pbaP7uMyK5M0pJ676WZ9lgbeKihsP267p/9o+wLr2f6fXsZzIPBUPt7WJXUT8YbSDfoXA7+1vSawJjCCdDx25x2StmowvmFeVeIeCEPtWBsIrdxGw7KgkLSHUj/yd0g6K4/bVtJNkm6T9CdJYySNBfYDDspXEJvafqmwqCVInX/VL38FSdfmee6UtKmko4ERedw5ksaq0M+9pEMkTczfp0j6oaSbJd2f518E+B6wS17GLsWz8nzGcLxSv/gP1c4eJC0g6SRJ90qaLOn3jc4scp7HFWL+cB4/UdJZkq4HzpK0vKSLJN2SPx/NecyUtHRheQ/kbfi27dog77cts5D3qTm2hyQd0M0+bLicurz2lHSppGuAqyWNlHS1pFvz2XStl9OjgXfl7fHj4v6StJik03L625T6+qnP51JgJDA976uxkq7JMV+t9FRvbb/9QtJNvP2HfgUKXV/Yvs/268DmwGu2T8vj3wQOIvUS0N1VwI+BbzUY3yyv+vXaMm+rOyRdncctK+m3ed1ulLReN8dE2f4uPdZyuuUkXaV0tfZrUjf/9XHup8KVXO1/Remp6Sty/HdK2qVsY+WYDikM35n35VhJ90j6VY7jKkkjcpp352P9jryt3qXkx3n+GbV8JU2S9KnC8k+XtJOkBXP6W/J2/e88vUvSX/PxdXdJOuX1vU/Sn0hd4vdeu/s5b/UHeB9wP7mveGDZ/HcZ5j2A+EXgmPx9Im9/18BXSP3t/xNYs0EeBwPfyt8XBEbl77MLacZS6OceOASYmL9PKeS/NfCn/H1P4MTCPG8NA6cDF5AK/3VI3TwD7ER6gnwB4J3A88BODWKeAvwqf9+sFlte/+nAiDx8LqnDM4BVgXvy9+OAvfL3DQsxN9uuxdibLXMicAOwKOlp5+dIT8Y224cNl1O3nnuSejOtzbMQsGT+Ppr0lL0a7J+3hvP+PTV/Xxv4B7BYg7yK+/sy4Av5+96kq4HafrscWLDB/OsDTwNTgSPIxxpwAPB/DdLflufpAi5vso/HA9cAE/L3KWV51c2/POmYX71uu58AHJ6/bw7c3s0xUba/qxxrxwPfzd8/RTpZG90g1r8Xhv9A6rTvP8nHeR6/VDe/FxOZ/10rd+ZjYSwwB1g/j/8NsFv+fhOwQ/6+GLB4zncy6fdgTD5mVgB2AM7IaRfJ23cE6Wr023n8oqQeAFbP+/blwj5olm7HQn4rAi/Q4P++6mc4Xt5tDlxg+1kA27X+5lcGzld6n8QiwMPNFmD7Z8DPJH0e+DbwhboktwCnSlqY9INwey/ivDj/nU46KKv4re25pDON2pn7JqT1nQs8KenPJfOfB6kffklLFs4GL7X9av7+CWAd6a2TuCXzWez5pC4NTiP17XN+nl5luzZbJsAVTme2r0t6mvRP1mwfNlyO7dl1+U0uzCPgB5I2A+aSusN+21VPnU1IP47YvlfSI8BawN9K5tmY9M8LcBbzXz1c4HRVMB/btyv1PrxFXrdbJG3cTWxVHEE6bv+3u7xs31OYbyPgWtsP53lq27D2A4zta/IZ/5I0PybK9neVY20z8ra0fYWk2jsh3mL7GaWr0I2AB0gF+vWkarpjJP2QVJj+tfJWe7uHC//b04GxSn08rWT7khzHawCSNgHOy/v5KUl/Ib306g/AcUrtS1uStu+rkrYA1tO8q/+lcuz/Bm6u7QPS/mqUbrNCfo8rXUH32nAsKJo5ATjW9qWSukhnEt2ZBPy8fmT+od2MdLZzuqRjbZ9Zl2wO81f9LVY3vXbZ/ybV91OxquBtl+MV1Fej1YZfLoxbANio9g/wVmbSVODdkpYHPk36MYJq27XZMmH+depuWzRcTgPF9dmVdPa5ge03JM3k7ftioL3cbEIu5C4GLlbqO2xr0hvj5qs+zD/M7wTuI529N5V/zI8g/fB3l9c9DRZRVbNjomx/VznWquY/CdgZuBe4xOm0+36lVxZvDRwh6Wrb3ytZRtn/af2xOaJqYDW2X1O6oeA/gF1yzJD+f/e3fWUxff4fKm6jZum2ph8NxzaKa4DPSFoOUv1qHr8U8+poi1cIs4BRtQFJaxamfYp0tjIfSauRGgZ/ReqCuPYu7TfyVQbAU6SGxeXy2cQ2FWKfL5aKrgf+U6nOeAzp0rWZWr3pJqSecF9skOYqYP/agKT1AfI/4SWkxv17PK/L5Wbbtdtllmi2D3u6nFp8T+dCYgKwWh5ftq3/SipgkLQWqVrkvm7yuYF0Vk2et9szWaX2n2Xy90VIVYqPAFcDi0vaI09bEDiGVJX3arPl1TkC+EaFvIpuBDaTtHpOV9vuxe3RBTxr+6WSY6LqfmqW7lrg83ncVqTqzUYuIb1Z73PkH2BJKwKv2D6b1F7zwSbz1syspckFzOpliW3PAh5VflmZpEUlLU7aRrvkNoXlSWf8N+fZzid1KLopUOs88ErgS7XfC0lrKfVEW69ZumsL+a1AqmrstWFXUDj1Ynkk8BdJdzDvrqWJwAWSpgPPFma5DNhBuTEb+KpS49XtwNdp/OPXBdwh6TbSj+9xefzJwN8knWP7DVLj9M2kusR7K4T/Z9Kl+O3qphGu4CJSnfzdwNnArUCjAgDgtRzzL0h3vTRyADBeqeHsblJjf835wG7Mq2KA5tu16jLfpmQf9mg52Tl5nhnAHuT9kH/UrldqfKy/vfUkYIE8z/nAnm7Q8Ftnf2AvSX8DdifdZdSdd5HWcQap/WEacFH+Ad4B2EnSA6S2m7m2jyzM+3FJjxY+81VZ2f498Ex3edXN8wypTvzivN1r+3kisEFet6OZ/3+i0TFRdT81S/f/SAXWXaQqqH80mtnpNaX3kF4iVvtRHgfcnP9/Dydf5Uj6nqTtGizmImDZnNdXSW1j3dkdOCBvjxtIV3qXkKom7yCd6HzD9pM5/VXAx0htOP/O435N+p+9Vekmil/S+Gq6WbpLSCexdwNnkq7uei16jx0GlOvp8xn4zcBHCwdpLc0UUqPdtEbLCJ1L6Tmf80gNqLe2O54w9EQbxfBwuVLD9CLA9+sLiTC42b6BeVVmIfS7uKIIIYRQati1UYQQQuiZKChCCCGUioIihBBCqSgoQgghlIqCIoQQQqn/D6fWTlzAot8EAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "stunting_prevalence_ratio.query(\"stunting_state == 'cat3'\").value.hist(bins=20, density=True)\n",
+    "plt.xlabel(\"cat3 stunting prevalence ratio for SQLNS covered vs. uncovered\")\n",
+    "plt.ylabel(\"Probability density over 288 combinations\\nof (year, sex, age, draw)\")\n",
+    "plt.title(\"Mild stuntining prevalence ratio histogram\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "b397b028",
    "metadata": {},
    "outputs": [
     {
@@ -1936,7 +2561,7 @@
        "Name: value, dtype: float64"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1946,33 +2571,746 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "07ba00b2",
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "4b208d2f",
    "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYoAAAEWCAYAAAB42tAoAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAA0rElEQVR4nO3deZgcVdn+8e8ddkjCFgg7AdlEAwhRQBESEGRHEUEEWcSXnyiCvKDgSkTUoAIKiLwo+5bIKqIIAYwgOwmEsIMYkC1I2BI2CTy/P85p0hm6q2tmeqZ7Zu7PdfU1XVWnqp5apk7XOVXnKCIwMzOrZ1CrAzAzs/bmjMLMzAo5ozAzs0LOKMzMrJAzCjMzK+SMwszMCjmjsJaSdL+k0c1O21dJCklrtDqOZpJ0mqQfdGG+EXl/zF9n+ncl/b77EVojziiaTNLsqs+7kt6oGt5L0th88h/aYb5D8/ixeXh0nn+2pFmSHpa0f4d5QtJrHdb57TxtrKTzu7ktZ0s6tjvLaLS8iPhQREwqM39n0lprSNpP0j+qx0XEVyPix81eV0T8NCK+UiKmSZIaprP6nFE0WUQMrnyAJ4GdqsZdkJM9AuzTYdZ98/hqz+TlDAUOA34nae0OadavXmdE/LzJm2RVlAzI/5t6v+wHsoGyTwbkCd8G7gQWlfQhgPx34Tz+fSL5C/AisF4zA8kXvhMlPS/pVUnTJH1Y0oHAXsC3853Kn3L6eYpGqu8S8l3QU5IOz8t7tnIXVLC86ZI+lb+PlfQHSefmu6j7JY2qWldn0m4o6e487WJJE+rdHeVfwTdLOkXSK5IekrRV1fRJkn4i6WbgdWB1SetImijpxXy3t3tOu7Gk5yTNVzX/ZyXdm79/TNKtkl7O++cUSQvWiWshSb+U9KSkGUpFOIs02td5+iKSjpf0RN6mf1TNu4mkW3IMU1VQnJf3+ZE5/tckzS/pKEn/zPv2AUmfzWk/CJwGbJqP8csdz5E8/D+SHsv77kpJK9Rbf7ZX3gcvSPpe1XLeu2uWtLCk8yXNzNt1p6Thkn4CfBI4Jcd0Sk7/8Zzmlfz341XLXU3SjXn7rpP0m6r1VIrDDpD0JHBDHn9xPu6v5Hk/VLW8syWdKunqHMPNkpaT9CtJL+Xz7SMN9kFLOaNonfOYe1exbx6uSdIgSTsDw4DHmhzHNsDmwFrA4sDuwMyIOB24APh5vlPZqeTylsvLWRE4APiNpCU7sbydgfHAEsCVwCkF66qZNl94LwfOBpYCLgI+2yDujYF/kvbx0cBlkpaqmv4l4EBgCPAfYCJwIbAs8AXgVEnrRsTtwGvAllXzfjGnBXiHdHc4DNgU2Ar4Wp2YxpGOywbAGqR9+sOq6TX3dZ72S2Aj4ON5H3wbeFfSisCfgWPz+COASyUtU7Bv9gR2AJaIiDl5P30yr/tHwPmSlo+IB4GvArfmY7xExwVJ2hL4Gek8Wx54gnQMi2wGrE3aVz/MGVJH++Z4VgaWznG8ERHfA24CDs4xHZyP65+Bk3LaE4A/S1o6L+tC4I48bSzp2He0BfBB4NN5+GpgTdL5MIV0rlfbHfg+6bi/Bdya0w0DLskxtC1nFK1zPrCnpAVIF5pa9Qkr5F9lb5AufP8bEXd3SDMl/4KqfD79vqUUe5t08VsHUEQ8GBHPdnIZHZd3TES8ne+CZpP+ycv6R0T8JSLeIWWe63ch7SbA/MBJOY7LSP/4RZ4HfpXTTwAeJl0cK86OiPvzhXJbYHpEnBURc/IxuRT4fE57EeniiqQhwPZ5HBExOSJuy/NNB/6PdNGZhySRMqbDIuLFiJgF/JR0rlTU3NdKRWNfBg6NiKcj4p2IuCUi3gL2Bv6S99u7ETERuCvHWM9JEfHviHgjb8PFEfFMnn8C8CjwsQb7t2Iv4MyImJLj+Q7pDmREwTw/iog3ImIqMJXa58TbpAv7Gnl7J0fEq3WWtwPwaEScl4/DRcBDwE6SVgE+CvwwIv4bEf8g/QjpaGxEvFa1T86MiFl5m8YC60tavCr95TmmN0n/y29GxLn53J0A+I7C3i8iniTdHfyUdNL+u0ayZ/KvsqGkXz9b1kizYUQsUfW5ppNx3ED6Jf4b4HlJp0sa2plldDAzX0wrXgcGd2L+5zrMu7DqlwPXS7sC8HTM2+Jlrf1brWP6J/Jyas2/KrBxdQZNugAul6dfCOwqaSFgV2BKRDwBIGktSVflYopXScd/WI14lgEWBSZXreOveXxFvX09jFSU+c8ay10V+HyH2Dcj/bqvZ559J2kfSfdUzf/hOttQywqkfQtARMwGZpLuiurpeJxrnU/nAdcA4yU9I+nn+UdYwxiyJ3IMKwAvRsTrVdNqnTvvjZM0n6RxuTjuVWB6nlS9T2ZUfX+jxnBn/kd6nTOK1joXODz/rSv/SjkSGCnpM80OIiJOioiNgHVJRR3fqkyqkfx10gWsYrkaaequqmsRdtqzwIr5V3nFyg3m6Zh+FeCZquGOmc7fO2TQgyPiIICIeIB04dmOeYudAH5L+vW6ZkQMBb4LVK+34gXSBeRDVetYPD/c0MgLwJvAB2pM+zdwXofYF4uIcQXLe2/bJa0K/A44GFg6/5C5r2obGh3jZ0iZVWV5i5HuBJ5uMF+hfFf1o4hYl1TctiNzi3Y7xjRPDNkqOYZngaUkVZ/jtc6d6mV+EdgF+BSp+GtEHl/ruPZJzihaawKpjuAPjRJGxH+B45m3jLqRQbmSr/JZqGMCSR9VqoBdgFS2/ibwbp48A1i9wyz3AF/Mv6K2pUaxSYFay+sJt5LqAg5WqnzdhcZFI8sCh0haQNLnSeXPf6mT9ipgLUlfyukXyPuxuuz8QuBQUv3PxVXjhwCvArMlrQMcVGsFEfEu6YJ8oqRlASStWKZoMc97JnCCpBXysdo0H//zSUUsn87jF1aqGF+p0XKzxUgXyf/kmPYn3VFUzABWUp0KelIR3P6SNsjx/BS4PRfDdZmkMZJGKj1E8CqpKKreefwX0vH7Yj4/9iD9SLoq3/ndBYyVtKCkTYFG9XNDSPUOM0k/on7anW1pR84oWiiXu15XKecs4UxgFUnVJ+5Uzfsexa+qpu1J+lVa+dQqihhKuiC9RPoVPBP4RZ52BrBuLmK4Io87lPSP8zKpuOUKyqu1vKbLmequpArel0nl8leR/pnruZ1UGfkC8BNgt4iYWWf5s0gZ/BdIv06fA44DqjPii0iZ6A0R8ULV+CNIv0Bnkfb7hIKYjiQVT96WizSuo3x9zxHANNKTdC/m+AblIs5dSHcy/yHdYXyLkteCfLd0PCkzngGMBG6uSnIDcD/wnKQXasx/HfADUp3Os6S7ni90TNcFy5EqhV8FHgT+ztwHRH4N7JafMDopH9cdSXfzM0kV/TtWHae9SA8azCRV+k+g+Nw5l/S/8zTwAHBbE7anrSjccZENAJJuB06LiLNqTNsP+EpEbNbrgVnbkzQBeCgijm51LK3iOwrrlyRtofSs+vyS9iW9f/LXVsdl7S8XI35A6bH0bUl3YFe0OKyWGhBvFdqAtDap7mcx4HFSUVJ3Hvu1gWM54DJSJftTwEE1HksfUFz0ZGZmhVz0ZGZmhfpd0dOwYcNixIgRrQ6jR7322msstthirQ6jxw2U7YSBs63ezvY1efLkFyKiZlMu/S6jGDFiBHfddVerw+hRkyZNYvTo0a0Oo8cNlO2EgbOt3s72Janj2+rvcdGTmZkVckZhZmaFnFGYmVkhZxRmZlaoYUYh6RO5hUck7S3phNyCpJmZDQBl7ih+C7wuaX1SI1r/pEGz2GZm1n+UySjm5A5ddgFOiYjfkJrVNTOzAaDMexSzJH2H1FTz5rmbxXo9R5mZWT9T5o5iD1Jb7AdExHPASsztr8DMzPq5hncUOXM4oWr4SVxHYdYlI476c83xh4+cw351plVMH7dDT4Rk1lCZp552lfSopFckvSppVu5ty8zMBoAydRQ/B3aKiAd7OhgzM2s/ZeooZjiTMDMbuMrcUdyV+4y9gqoOxiPismYHI2k6qdP5d0iP5Y6StBSpc/MRwHRg94h4qdnrNjOz2srcUQwFXge2AXbKnx17MKYxEbFBRIzKw0cB10fEmsD1edjMzHpJmaee9u+NQArsAozO388BJgFHtioYM7OBpsxTTytJulzS8/lzqaSVeiieAK6VNFnSgXnc8Ih4Nn9/DhjeQ+s2M7MalFrnKEggTQQuBM7Lo/YG9oqIrZsejLRiRDwtaVlgIvAN4MqIWKIqzUsRsWSH+Q4EDgQYPnz4RuPHj292aG1l9uzZDB48uNVh9Lj+uJ3Tnn6l5vjhi8CMN4rnHbni4j0QUe/qj8e0lr64nWPGjJlcVeQ/jzIZxT0RsUGjcc0maSwwG/gfYHREPCtpeWBSRKxdb75Ro0aFu0LtH/rjdha9cHf8tOKS4P7wwl1/PKa19MXtlFQ3oyhTmT0zNy8+X/7sDcxsboggaTFJQyrfSZXn9wFXAvvmZPsCf2z2us3MrL4yj8d+GTgZOJFUh3AL0BMV3MOByyVV4rowIv4q6U7gD5IOAJ4Adu+BdZuZWR1lnnp6Ati5pwOJiMeB9WuMnwls1dPrNzOz2upmFJK+HRE/l3Qy6U5iHhFxSI9GZmZmbaHojqLSbEf/rhk2M7NCdTOKiPhT/vp6RFxcPU3S53s0KjMzaxtlKrO/A1xcYpxZn1DvEdWy+sNjqmadUVRHsR2wPbCipJOqJg0F5vR0YGZm1h6K7iieIdVP7AxMrho/CzisJ4MyM7P2UVRHMRWYKunCiHi7F2MyM7M2UqaOYoSknwHrAgtXRkbE6j0WlZmZtY0yGcVZwNGkN7PHkN7KLtP0h1m/1N3KcLO+pswFf5GIuJ7UgOATETEW8GMfZmYDRJk7irckDQIelXQw8DTQt9rPNTOzLitzR3EosChwCLAR8CXmtuZqZmb9XJlGAe/MX2fTM63GmplZG2uYUUhaC/gWsGp1+ojYsgfjMjOzNlGmjuJi4DTgd8A7PRuOmZm1mzIZxZyI+G2PR2JmZm2pTGX2nyR9TdLykpaqfHo8MjMzawtl7igqTzh9q2pcAH4z28xsACjz1NNqvRGImZm1p6JmxreMiBsk7VprekRc1nNhmZlZuyi6o9gCuAHYqca0AJxRmJkNAEXNjB+d//olOzOzAazhU0+SlpZ0kqQpkiZL+rWkpXsjODMza70yj8eOB/4DfA7YLX+f0JNBmZlZ+yjzeOzyEfHjquFjJe3RUwGZWW3d6Qdj+jj3DGBdV+aO4lpJX5A0KH92B67p6cDMzKw9FD0eO4v0dJOAbwLn50mDSC3JHlEw75LACsAbwPSIeLdJ8ZqZWS8reuppSGcWJGlx4OvAnsCCpLqMhYHhkm4DTo2Iv3UjVjMza4EydRRIWg8YwbzNjHd8j+IS4FzgkxHxcof5NwK+JGn1iDijOwGbmVnvKtMfxZnAesD9QKUI6X0v3EXE1vWWERGTgcldD9PMzFqlzB3FJhGxbtkFSjof+DtwU0Q81OXIzMysLZR56ulWSaUzCuAMYHngZEmPS7pU0qFlZpQ0n6S7JV2Vh1eTdLukxyRNkLRgJ+IwM7MmKJNRnEvKLB6WdK+kaZLurZc4V1j/BPgBqVe8UcBBJeM5FHiwavg44MSIWAN4CTig5HLMzKxJyhQ9nQF8CZjG3DqKuiRdDywG3ArcBHw0Ip4vMd9KwA6kTOZ/JQnYEvhiTnIOMBZwb3tmZr1IEVGcQLo1IjYtvUDpRGAj4C3gZuBG4NaIeKPBfJcAPwOGkN7R2A+4Ld9NIGll4OqI+HCNeQ8EDgQYPnz4RuPHjy8bbp80e/ZsBg8e3OowelxPbee0p19p+jK7a/giMKPwP6R7Rq64eM8tvBN87ravMWPGTI6IUbWmlbmjuFvShcCfSBd/oH5/FBFxGICkIaSL/VnAcsBC9VYgaUfg+YiYLGl0iZg6rvN04HSAUaNGxejRnV5EnzJp0iT6+zZCz23nft1oCqOnHD5yDsdPK/W0epdM32t0jy27M3zu9k1lzsxFSBnENlXj6vZHIelg4JOku4rpwJmkIqginwB2lrQ96SW9ocCvgSUkzR8Rc4CVgKdLxGtmZk1UpivUzvZHsTBwAjA5X+AbiojvAN8ByHcUR0TEXpIuJrVYO57Ud/cfOxmLmZl1U5n+KFaSdLmk5/Pn0lzxXFNE/DIibgeWkrRK5dPF+I4kVWw/BixNqlg3M7NeVObx2LOAK0mN/K1Aqqs4q15iSTtJehT4F+nFu+nA1WUDiohJEbFj/v54RHwsItaIiM9HxFuN5jczs+Yqk1EsExFnRcSc/DkbWKYg/bHAJsAjEbEasBVwW/dDNTOzViiTUcyUtHd+a3o+SXsDMwvSvx0RM4FBkgblF/BqPnJlZmbtr8xTT18GTgZOJD3tdAtQVMH9sqTBpPcnLpD0PPBadwM1M7PWKPPU0xPAzp1Y5i6kDosOA/YCFgeO6VJ0ZmbWcmWeejpH0hJVw0vmpsdrpZ0PuCoi3s31GedExEm5KMrMzPqgMkVP61V3RBQRL0n6SK2EEfGOpHclLR4R7ddOgrWVEQ3ekD585Jy6b1FPH7dDT4RkZjWUySgGSVoyIl4CkLRUg/lmA9MkTaSqbiIiDulWpGZm1hJlMorjSc2MX5yHP09q4bWey6jTvIeZmfU9ZSqzz5V0F6nJb4BdI+KBgvTnNCs4MzNrvVLNVeaMoW7mACBpGunx2XrLWK9zoZmZWTtoZrvGO+a/X89/z8t/96YgAzEzs/bWtIwiv2+BpK0jovqpqCMlTQGOata6zMys9xS+RyFp/qrvgyWNyk89NZhNn6ga+Hij9ZiZWfuqewGXtB8wQ9IjkrYD7gWOA6ZK2rNgmQcAp0qaLmk6cCqpGRAzM+uDioqeDgfWJvVhPRX4SET8U9JwYCJwUa2ZImIysL6kxfOwX7wzM+vDijKKdyLiBeAFSbMj4p8AETFDUsMFO4MwM+sfijKKJyX9jHRH8ZCk40kv0n0KeLY3gjMzs9YrqmTeG3gVeIrUeuytpH6thwP79XhkZmbWFureUUTEq8DPqkZdkj+dImkU8ExEPNP58MzMrNWKnnoaJelvks6XtLKkiZJelnRnvdZj6/gG8GdJE7ofrpmZ9baiOopTgaOBJUi92h0WEVtL2ipP27TMCiJiXwBJQ7oXqpmZtUJRRrFARFwNIOm4iLgEICKul/TLejMpPRK1F7B6RBwjaRVguYi4o5mBm1l5jfr+KOK+P6yoMvtNSdtI+jwQkj4DIGkL4J2C+Sp3G5WX8mYBv2lCrGZm1gJFdxRfBX4OvAt8GjhI0tnA08CBBfNtHBEbSrob3usRb8EmxWtmZr2s6KmnqaQMouLQ/Gnk7dx3dgBIWoaU2ZiZWR/UqFHAdSRtJWlwh/HbFsx2EnA5sKyknwD/AH7a7UjNzKwlih6PPQT4I+nx1vsk7VI1ue6FPyIuAL5NegfjWeAzEXFxvfRmZtbeiuoo/gfYKCJmSxoBXCJpRET8Gqjb2FNuhvx5qhoNlLRARLzdpJjNzKwXFWUUgyJiNkBETJc0mpRZrEpBRgFMAVYGXsrplgCekzQD+J/cuqyZmfURRXUUMyRtUBnImcaOwDBgZMF8E4HtI2JYRCwNbAdcBXyN9OismZn1IUUZxT7Ac9UjImJOROwDbF4w3yYRcU3VPNcCm0bEbcBC3QnWzMx6X92MIiKeiojn6ky7uWCZz0o6UtKq+fNt0t3JfBQ8JitpYUl3SJoq6X5JP8rjV5N0u6THJE3wOxlmZr2rqI6iq75IaiPqijx8cx43H7B7wXxvAVvmyvMFgH9Iuhr4X+DEiBgv6TRSV6u/7YG4rQ/pTpMUZtY5Tc8ocq9436gz+bGC+QKYnQcXyJ8AtiRlNADnAGNxRmFm1muUrs91JqbiousiYkzpBaY3sb8NfAhYuDI+IrYsMe98wGRgDVL7UL8AbouINfL0lYGrI+LDHeY7kNysyPDhwzcaP3582XD7pNmzZzN48ODGCdvctKeLe8sdvgjMeKOXgmmxdt7WkSsu3rRl9Zdzt5G+uJ1jxoyZHBGjak0rvKOIiHckvStp8U70gX0BMIH0hNRXgX2B/5SZMSLeATaQtATp7e51Ss53OnA6wKhRo2L06NElQ+2bJk2aRH/Yxv0aFB8dPnIOx0/ridLR9tPO2zp9r9FNW1Z/OXcb6W/bWebMnA1MkzQReK0yMiIOqZN+6Yg4Q9KhEfF34O+S7uxMUBHxsqS/kVqhXULS/BExB1iJ1CihmZn1kjIZxWX5U1blDexnJe0APAMs1WimXGT1ds4kFgG2Bo4D/gbsBown3Z38sROxmJlZNzXMKCLinHzhXiUiHi6xzGMlLQ4cDpwMDAUOKzHf8sA5uZ5iEPCHiLhK0gPAeEnHAncDZ5RYlpmZNUnDjELSTsAvgQWB1fLb2sdExM610kfEVfnrK0DpSvCIuBd4X1/cEfE48LGyyzEzs+YqbGY8G0u6UL8MEBH3AKv3WERmZtZWymQUb9d44skdEZmZDRBlKrPvl/RFYD5JawKHALf0bFhmZtYuytxRfIP08txbwIWkuodvll2BpF0kbdyl6MzMrOXK3FGsExHfA77XxXVsDIzM70Js18VlmJlZi5TJKI6XtBxwCTAhIu7rzAoi4rtdiszMzNpCw6Kn3M7TGFIzHP8naZqk79dLL+nHkuavGh4q6aymRGtmZr2uTB0FEfFcRJxEarvpHuCHBcnnB26XtJ6krYE7SQ39mZlZH1TmhbsPAnuQmtF4gdTg3+H10kfEdyRdB9xO6jd784io27y4mZm1tzJ1FGeS2lnaJiKeaZRY0ubAScAxpL61T5Z0QJl5zcys/ZRp62nT3P3oWpKWAh6OiLcLZvkl8PmIeABA0q7ADZRsMtzMzNpLmaKnLYBzgemAgJUl7RsRN9aZZdPcrwQAEXGZpL83I1gzM+t9ZSqzTyAVO20REZsDnwZOLEj/AUnXS7oPQNJ6wEHdD9XMzFqhTB3FAtXNi0fEI5IWKEj/O+BbwP/l9PdKuhA4tluRmllLjGjQE2Ej08ft0KRIrFXKZBR3Sfo9cH4e3gu4qyD9ohFxh6TqcXO6GJ+ZmbVYmYziIODrpMYAAW4CTi1I/4KkDwABIGk34NnuBGlmZq1T5qmnt0j1FCeUXObXgdOBdSQ9DfwL2LvLEZqZWUuVuaPolNwj3ackLQYMiohZzV6HmZn1nlJNeHSGpEMlDQVeB06UNEXSNs1ej5mZ9Y6GGYWkkZ1c5pcj4lVgG2Bp4EvAuC7EZmZmbaDMHcWpku6Q9DVJi5dIX3ncaXvg3Ii4v2qcmZn1MWWaGf8k6ZHYlYHJki7MrcLWM1nStaSM4hpJQ3Af22ZmfVapyuyIeDT3QXEXqcG/jyi9KPHdiLisQ/IDgA2AxyPidUlLA/s3MWYzM+tFZdp6Wo90od8BmAjsFBFTJK0A3ArMk1FExLvAlKrhmcDMZgZtZma9p8wdxcnA70l3D29URkbEM0U93ZmZWf9QpjL78og4rzqTkHQoQESc12ORmZlZWyiTUexTY9x+TY7DzMzaVN2iJ0l7Al8EVpN0ZdWkIcCLZVcg6cH89TcRcUqXojQzs5YpqqO4hdSY3zDg+Krxs4B7y64gIj6Yn3zapEsRmplZS9XNKCLiCeAJYNOyC5M0H3BdRIzpsKyZQPcatTczs5aoW0ch6R/57yxJr1Z9Zkl6tdY8uQvUd0u+wW1mZn1A0R3FZvnvkE4uczYwTdJE4LWq5R1SfxaQtDKpb+7hpL4sTo+IX0taCpgAjCD12717RLzUyZjMzKyLyrxw9wHgqYh4S9JoYD1SG04v15nlMjq8hFfSHODw/DLfEFJTIBNJT1hdHxHjJB0FHAUc2YXlm5lZF5R54e5SYJSkNUgdEv0RuJDUltP7RMQ5XQkkIp4l94QXEbPy01IrArsAo3Oyc4BJOKMwM+s1iojiBNKUiNhQ0reANyPiZEl3R8RH6qRfE/gZsC6wcGV8RKxeOihpBHAj8GHgyYhYIo8X8FJluCr9gcCBAMOHD99o/PjxZVfVJ82ePZvBgwe3Ooxum/b0K4XThy8CM94oTNJv9OdtHbni3CrL/nLuNtIXt3PMmDGTI2JUrWll7ijezu9U7AvslMctUJD+LOBo4ERgDKmdqNIdJEkaTLqL+WZEvJryhiQiQtL7craIOJ10t8OoUaNi9OjRZVfXJ02aNIn+sI37HVX8INzhI+dw/LSmd8LYlvrztk7fa/R73/vLudtIf9vOMhfw/UmPyP4kIv4laTWgqOmORSLietLdyhMRMZbUoGBDkhYgZRIXVLVKO0PS8nn68sDzZZZlZmbN0fAnTEQ8ABxSNfwv4LiCWd6SNAh4VNLBwNNAw3uwXKx0BvBgRJxQNelK0t3MuPz3j42WZWZmzVOmK9RPSJoo6RFJj0v6l6THC2Y5FFiUlLlsBOxNusA38glSt6lbSronf7YnZRBbS3oU+BTuVtXMrFeVKRQ9AzgMmAy80yhxRNwJIOndiCjdYVFE/IP6XaZuVXY5ZmbWXGXqKF6JiKsj4vmImFn51EssaVNJDwAP5eH1JZ3arIDNzKx3lbmj+JukX5BeonurMjIiptRJ/yvg06S6BSJiqqTNuxmnmZm1SJmMYuP8t/r52gC2rDdDRPy7+rFWShRZmZlZeyrz1NOYRmk6+LekjwORH3c9FHiwwTxmZtamyjz1NFzSGZKuzsPrSjqgYJavAl8nNb/xNLBBHjYzsz6oTGX22cA1wAp5+BHgmwXpIyL2iojhEbFsROxdVPltZmbtrUxGMSwi/gC8CxARcyiuc7hN0sWStlOHigozM+t7ymQUr+WuTANA0iZAUWtua5HaXdqH9Hb2TyWt1e1IzcysJco89fS/pEddPyDpZmAZYLd6iSM1RzsRmChpDHA+8DVJU4GjIuLW7odtZma9pcxTT1MkbQGsTXpz+uGIeLte+nz3sTepOY4ZwDdIGc0GwMXAat0P28zMekvdjELSrnUmrSWJqtZdO7qV1LrsZyLiqarxd0k6rYtxWpsa0aCpcDPr+4ruKCp9TywLfBy4IQ+PAW6hfnena0ed3pAioqjVWTMza0N1M4pKg36SrgXWzV2VVvqEOLtjekm/A06KiGk1pi0G7AG8FREXNCd0MzPrDWUqs1euZBLZDGCVGul+A/xA0kjgPuA/pK5Q1wSGAmcCziTMzPqYMhnF9ZKuAS7Kw3sA13VMFBH3ALvnrkxHAcsDb5A6Inq4OeGamVlvK/PU08GSPgtUWoA9PSIuL0g/G5jUnPDMzKzVSvXmnjOGupmDmZn1X2XezDYzswGsaRmFpPPy30ObtUwzM2u9Ms2M7ySpTIaykaQVgC9LWlLSUtWf7odqZmatUKaOYg/gV5IuBc6MiIfqpDsNuB5YHZhMau6jIvJ4MzPrY8o89bS3pKHAnsDZkgI4C7goImZVpTsJOEnSbyPioB6L2JrOzXCYWZFSdRQR8SpwCTCe9H7EZ4Epkr5RI+1BktaXdHD+rNfUiM3MrFeVqaPYRdLlpHcjFgA+FhHbAesDh9dIfwjpDexl8+eCWhmKmZn1DWXqKHYFToyIG6tHRsTrdfrO/gqwcUS8BiDpOFKLsid3N1gzM+t9ZYqenuuYSeSLPxFxfY30Yt6uUt9h3optMzPrQ8pkFFvXGLddQfqzgNsljZU0FrgNOKMLsZmZWRso6rjoIOBrpC5Q762aNAS4ud58EXGCpEnAZnnU/hFxdxNiNTOzFiiqo7gQuBr4GXBU1fhZEfFi0UIjYgowpfvhmZlZqxVlFBER0yV9veMESUs1yizMzKx/aHRHsSPpLevAb1qbmQ1IRV2h7pj/rtYbgUg6k5QxPR8RH87jlgImACOA6cDuEfFSb8RjZq3XnVYDpo/boYmRDGx1n3qStGHRpwdiORvYtsO4o4DrI2JNUjtSR3WcyczMelZR0dPxBdMC2LKZgUTEjZJGdBi9CzA6fz+H9Hb4kc1cr5mZFVNEtDqG9+SM4qqqoqeXI2KJ/F3AS5XhDvMdCBwIMHz48I3Gjx/fWyG3xOzZsxk8eHDTljft6VeatqxmGr4IzHij1VH0jv68rSNXXPy97509d7tzblavt7c1+3+0N4wZM2ZyRIyqNa3oPYotI+IGSbvWmh4RlzUrwDIiInLLtbWmnQ6cDjBq1KgYPXp0b4bW6yZNmkQzt3G/Nm099vCRczh+Wqneevu8/ryt0/ca/d73zp673Tk3q9fb25r9P9pqRWfmFsANwE41pgXQGxnFDEnLR8SzkpYHnu+FdZqZWZWip56Ozn/3771w3udKYF9gXP77xxbGYmY2IJVpZnxpSSdJmiJpsqRfS1q62YFIuojUyuzakp7KLdOOA7aW9CjwqTxsZma9qEyh6HjgRuBzeXgv0rsNn2pmIBGxZ51JWzVzPWZm1jllMorlI+LHVcPHStqjpwIyM7P2UqaZ8WslfUHSoPzZHbimpwMzM7P2UPR47CzmtvH0TeD8PGkQMBs4oqeDM7O+r7oZjsNHzmnbx7GtvqKnnob0ZiBmZtaeSr3hI2lJYE1g4cq4jt2jmplZ/9Qwo5D0FeBQYCXgHmAT0mOsTW3ryczM2lOZyuxDgY8CT0TEGOAjwMs9GZSZmbWPMkVPb0bEm5KQtFBEPCRp7R6PzErrTpv9ZmaNlMkonpK0BHAFMFHSS8ATPRmUmZm1j4YZRUR8Nn8dK+lvwOLAX3s0KjMzaxtln3raENiM9F7FzRHx3x6NyszM2kaZRgF/SOpdbmlgGHCWpO/3dGBmZtYeytxR7AWsHxFvAkgaR3pM9tgejMvMzNpEmcdjn6HqRTtgIeDpngnHzMzaTVFbTyeT6iReAe6XNDEPbw3c0TvhmZlZqxUVPd2V/04GLq8aP6nHojEzs7ZT1CjgOZXvkhYE1sqDD0fE2z0dmJmZtYcybT2NJj31NJ3U5PjKkvZ1o4BmZgNDmaeejge2iYiHASStBVwEbNSTgQ00nWmGw236m/Ws7jaLc/a2izUpkvZQ5qmnBSqZBEBEPAIs0HMhmZlZOylzRzFZ0u+Z28PdXsyt6DYzs36uTEbxVeDrwCF5+Cbg1B6LyMzM2kphRiFpPmBqRKwDnNA7IZmZWTspzCgi4h1JD0taJSKe7K2gzMy6y/20NE+ZoqclSW9m3wG8VhkZETv3WFRmZtY2ymQUP+jxKMzMrG0VtfW0MKkiew1gGnBGRMzprcDMzKw9FL1HcQ4wipRJbEd68c7MzAaYoqKndSNiJICkMxggLcZ2pwJs+rgdmhiJmQ1E7XgNKrqjeK/hPxc5mZkNXEV3FOtLejV/F7BIHhYQETG0x6MzM7OWq3tHERHzRcTQ/BkSEfNXfe/VTELStvl9jsckHdWb6zYzG+jKNArYUvnt8N+QKtTXBfaUtG5rozIzGzjaPqMAPgY8FhGPR8R/gfHALi2OycxswFBEtDqGQpJ2A7aNiK/k4S8BG0fEwVVpDgQOzINrAw+/b0H9yzDghVYH0QsGynbCwNlWb2f7WjUilqk1ocyb2W0vIk4HTm91HL1F0l0RMarVcfS0gbKdMHC21dvZN/WFoqengZWrhlfK48zMrBf0hYziTmBNSatJWhD4AnBli2MyMxsw2r7oKSLmSDoYuAaYDzgzIu5vcVitNlCK2QbKdsLA2VZvZx/U9pXZZmbWWn2h6MnMzFrIGYWZmRVyRtFGGjVVImlVSddLulfSJEkrVU37uaT7JT0o6SRJ6t3oO6eb23qcpPvyZ4/ejbxzJJ0p6XlJ99WZrny8HsvbumHVtH0lPZo/+/Ze1J3Xze38q6SXJV3VexF3TVe3U9IGkm7N/6P3tvt5+z4R4U8bfEgV9f8EVgcWBKaSmnqvTnMxsG/+viVwXv7+ceDmvIz5gFuB0a3eph7a1h2AiaQHMRYjPRU3tNXbVLCtmwMbAvfVmb49cDWpsc1NgNvz+KWAx/PfJfP3JVu9Pc3ezjxtK2An4KpWb0cPHs+1gDXz9xWAZ4ElWr09ZT++o2gfZZoqWRe4IX//W9X0ABYmXXQXAhYAZvR4xF3XnW1dF7gxIuZExGvAvcC2vRBzl0TEjcCLBUl2Ac6N5DZgCUnLA58GJkbEixHxEilz7I/bSURcD8zqhTC7ravbGRGPRMSjeRnPAM8DNd+CbkfOKNrHisC/q4afyuOqTQV2zd8/CwyRtHRE3Eq6mD6bP9dExIM9HG93dHlb8/htJS0qaRgwhnlfyOxr6u2LMvuoL+lv21NPw+2U9DHSj7p/9mJc3eKMom85AthC0t3AFqQ31N+RtAbwQdJb6ysCW0r6ZOvCbIqa2xoR1wJ/AW4BLiIVs73TsijNOiHfRZ0H7B8R77Y6nrKcUbSPhk2VRMQzEbFrRHwE+F4e9zLpF/dtETE7ImaTykg37ZWou6Y720pE/CQiNoiIrUllwY/0StQ9o96+6G9N1/S37amn7nZKGgr8GfheLpbqM5xRtI+GTZVIGiapcsy+A5yZvz9J+vU9v6QFSL/A27noqcvbKmm+XASFpPWA9YBrey3y5rsS2Cc/LbMJ8EpEPEtqiWAbSUtKWhLYJo/rq+ptZ39TczvzeX45qf7iktaG2Hlt34THQBF1miqRdAxwV0RcCYwGfiYpgBuBr+fZLyE9GTSNVLH914j4U29vQ1nd3NYFgJvy07+vAntHG/fpLuki0rYMk/QUcDRpG4iI00jFaNsDjwGvA/vnaS9K+jEpUwU4JiKKKlFbqqvbmee9CVgHGJznPSAi2jJT7MZ27k56YmppSfvlcftFxD29FXt3uAkPMzMr5KInMzMr5IzCzMwKOaMwM7NCzijMzKyQMwozMyvkjKIBSaMlfbzG+M9JCkmlO1CX9N1uxrKBpO2rhndWjZZX+wJJ+0k6pdVx1CNpCUlfqxpeQVKnnn+X9IvcWugvuhjDopIukDRNqaXcf0ganKetJOmPuWXZxyWdImmhPG10rZZYlVrhvatqeJSkSY3W1e4kTc/NuVgdks6WtFtX53dG0dhoUuus75E0BDgUuL2Ty+pWRgFsQHpGG4CIuDIixnVzmaVJ6lfv3TTYniWA9zKK/KZ4Z//RDgTWi4hvdTGeQ4EZETEyIj4MHAC8rfQSyWXAFRGxJrAmsAjw8xKrWVbSdjXG11xXmbh7Qn8713pCb+6jAZlRSNontwk/VdJ5edxOkm6XdLek6yQNlzQC+CpwmKR7qtpP+jFwHPBmneUvL+nGPM99kj4paRywSB53gaQRqmrTXtIRksbm75OU+ly4Q9Ijef4FgWOAPfIy9qj+VZ5/MZwk6Zb8C3O3PH6QpFMlPSRpoqS/1Pplkdf566qYP5bHj5V0nqSbgfMkLSPpUkl35s8n8jqmS1qianmP5n34vv1aY93vW2bVus/MsT0u6ZAGx7Dmcjqsaz9JV0q6Abhe0mClfi+m5F/TlVZqxwEfyPvjF9XHS9LCks7K6e+WNKbGeq4EBgOT87EaIemGHPP1klapOm6nSbqd91/ol6eqmYuIeDgi3iK9XPlmRJyVx78DHEZ6I7jRXcAvyE2ilFxXx+3aNu+rqZKuz+OWknRF3rbbJK3X4JwoOt6F51pOt7Ska5Xu1n5PasalY5xfVdWdXOV/RdJikv6c42/Yn0mO6Yiq4fvysRyh1PfL73Ic10paJKdZI5/rU/O++oCSX+T5p1XWK2m8pB2qln+2pN2UWiD4Rd7ueyX9vzx9tKSb8vn1QEE65e19WNJ1wLJF29lQq9s57+0P8CFS20DD8vBS+e+SzH0B8SvA8fn7WOCIqvk3BC7N3ycBo2qs43BSey6Q3jwekr/Prkozgqo27UmN4I2tWm5l/dsD1+Xv+wGnVM3z3jBwNqkPh0Gkprgfy+N3I70tOghYDngJ2K1GzJOA3+Xvm1diy9s/GVgkD18IbJa/rwI8mL//mtTQGcDGVTHX26/Vsddb5lhS438LAcOAmaS3YOsdw5rL6bCd+5Fa9KzMMz+5P4u8jsdIF56Ox+e94Xx8z8zf1yE1obJwjXVVH+8/Mbd/jS+T7gYqx+0qYL4a829Aao76VuBY5vZncAhwYo30d+d5RlOjb4d8jEeRmm8fk79PKlpXh/mXIbWMulqH/X4ycHT+viVwT4Nzouh4lznXTgJ+mL/vQGqNYFiNWB+rGr4a2Az4HPk8z+MXb3C9GMu8///35XNhBDAH2CCP/wOplQBIJQ2fzd8XBhbN651Iuh4Mz+fM8qR22s7JaRfM+3cR0t3o9/P4hYC7gNXysX2t6hjUS7dr1fpWAF6mxv992c9AvL3bErg4Il6A1FRCHr8SMEGpdccFgX91nFGp7aETSBebIncCZyq1u3RFdO01/cvy38mkk7KMKyK1SPmA5v5y34y0ve8Cz0n6W8H8F0Fqc1/S0Kpfg1dGxBv5+6eAdTW3A72h+VfsBOCHwFmktpsm5OkN92vBMgH+HOmX7VuSnif9k9U7hjWXE6mhxGoTq+YR8FNJmwPvklrffd9dTwebkS6ORMRDkp4gdUxzb8E8mzK32fTzmPfu4eJIdwXziIh7JK1OaufpU8CdkprR2OOxwPeBIxutK+Ztrn4TUl8g/8rzVPZh5QJMRNyQf/EPpf45UXS8y5xrm5P3ZUT8WdJLHTcwIv6jdBe6CfAoKUO/mVRMd7yk40iZ6U2l99r7/avqf3syMEKpWHrFiLg8x/EmgKTNgIvycZ4h6e/AR0kZ2K+V6pe2Je3fNyRtA6ynuXf/i+fY/wvcUTkGpONVK93mVet7RukOussGYkZRz8nACRFxpaTRpF8SHQ0BPgxMyifvcsCVknaOiPcqCfOFdnPSr52zJZ0QEed2WNYc5i36W7jD9Mpt/zuUP07VRQVd6Qq1Y3suleHXqsYNAjap/AO8tzLpVmANScsAnyFdjKDcfq23TJh3mxrti5rLqaF6e/Yi/frcKCLeljSd9x+LnvZavQk5k7sMuEzSu6Q7zKmkO8X35AvzcsDDpF/vdeWL+bGkC3+jdXWnccl650TR8S5zrpVd/3hSG0sPAZdH+tn9iFL3pNsDx0q6PiKOKVhG0f9px3NzkbKBVUTEm0oPFHwa2CPHDOn/9xvRoc2r/D9UvY/qpdueJhqIdRQ3AJ/X3BZIl8rjF2duGe2+VelnkTIIIuKViBgWESMiYgRwGzBPJpGXuSqpYvB3wO9JxVWQKiIXyN9nkCoWl86/JnYsEft7sXTCzcDnlMqMh5NuXeuplJtuRmr18pUaaa4FvlEZkLQBQP4nvJx0x/VgRMzMSert14bLLFDvGHZ2OZX4ns+ZxBhg1Ty+aF/fRMpgkLQWqVjk4QbruYX0q5o8b8Nfskr1P0vm7wuSihSfAK4HFpW0T542H3A8qSjvjXrL6+BY4Nsl1lXtNmBzSavldJX9Xr0/RgMvRMSrBedE2eNUL92NwBfzuO1IxZu1XE7qcW5P8gVY0grA6xFxPqm+ZsM681ZMr6TJGcxqRYkjYhbwlKTP5HkWkrQoaR/tkesUliH94r8jzzaB1HjgJ4G/5nHXAAdVrheS1pK0WI1V1kt3Y9X6licVNXbZgMsoIuJ+4CfA3yVNJZ3EkH7pXixpMvBC1Sx/Aj6reSuzGxkNTFXqdGcPUlktwOnAvZIuiIi3SZXTd5DKEh8qsdy/kW7F71H5ztkvJZXJPwCcD0wBamUAAG/mmE8jPfVSyyHAqFxx9gCpsr9iArA3c4sYoP5+LbvM9yk4hp1aTnZBnmcasA/5OOSL2s1KlY8dH289FRiU55lAagX0fRW/HXwD2F/SvcCXSE8ZNfIB0jZOI9U/3EWqHwtS2fZukh4l1d28GxE/qZp3K0lPVX3mKbKKiL8A/2m0rg7z/IdUJn5Z3u+V4zwW2Chv2zjm/UFQ65woe5zqpfsRKcO6n1QE9WStmSN1IfsgsGpEVC7KI4E7JN1Davn1WABJx0jaucZiLgWWyus6mHJ9n3wJOCTvj1tId3qXk4omp5J+6Hw7Ip7L6a8ldQ1wXaSugSH9wHwAmKL0EMX/Uftuul66y0lFbg8A55Lu7rrMrccOAMrl9PkX+B3AJ6pO0kqaSaRKu7tqLcPal9J7PheRKlCntDoe639cRzEwXKVUMb0g8OOOmYT1bRFxC3OLzMyazncUZmZWaMDVUZiZWec4ozAzs0LOKMzMrJAzCjMzK+SMwszMCv1/517/ElbWsoYAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "# 3. Verify incidence of moderate wasting from mild in supplemented vs non-supplemented group"
+    "stunting_prevalence_ratio.query(\"stunting_state == 'cat4'\").value.hist(bins=20, density=True)\n",
+    "plt.xlabel(\"cat4 stunting prevalence ratio for SQLNS covered vs. uncovered\")\n",
+    "plt.ylabel(\"Probability density over 288 combinations\\nof (year, sex, age, draw)\")\n",
+    "plt.title(\"TMREL stuntining prevalence ratio histogram\");"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "29686810",
+   "id": "694dfa7a",
    "metadata": {},
    "source": [
-    "# 4. Validation: Check that the prevalence of moderate wasting in supplemented vs non-supplemented group agrees with the prevalence RR that we applied to the incidence instead"
+    "# 3. Verify incidence of moderate wasting from mild in supplemented vs non-supplemented group\n",
+    "\n",
+    "Not done yet."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3cca2be4",
+   "id": "4f08e652",
    "metadata": {},
    "source": [
-    "# 5. Validation: Check to see how much of SAM prevalence decreases from reduction in MAM incidence from MILD"
+    "# 4. Validation: Check that the prevalence of moderate wasting in supplemented vs non-supplemented group agrees with the prevalence RR that we applied to the incidence instead\n",
+    "\n",
+    "The RR applied to the incidence rate of moderate wasting was 0.82 (95% CI 0.74 to 0.91). This was actually a prevalence ratio, so we want to see whether we get the same reduction in prevalence of moderate wasting.\n",
+    "\n",
+    "## The prevalence ratio does _not_ agree with the incidence ratio\n",
+    "\n",
+    "It is about 0.87 (95% UI 0.83 to 0.92), which is higher than the target 0.82."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "7d25e64e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>sex</th>\n",
+       "      <th>year</th>\n",
+       "      <th>wasting_state</th>\n",
+       "      <th>measure</th>\n",
+       "      <th>input_draw</th>\n",
+       "      <th>scenario</th>\n",
+       "      <th>value</th>\n",
+       "      <th>sq_lns</th>\n",
+       "      <th>age</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>female</td>\n",
+       "      <td>2022</td>\n",
+       "      <td>mild_child_wasting</td>\n",
+       "      <td>state_person_time</td>\n",
+       "      <td>29</td>\n",
+       "      <td>baseline</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>covered</td>\n",
+       "      <td>early_neonatal</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>female</td>\n",
+       "      <td>2022</td>\n",
+       "      <td>mild_child_wasting</td>\n",
+       "      <td>state_person_time</td>\n",
+       "      <td>29</td>\n",
+       "      <td>baseline</td>\n",
+       "      <td>410.098563</td>\n",
+       "      <td>uncovered</td>\n",
+       "      <td>early_neonatal</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>female</td>\n",
+       "      <td>2022</td>\n",
+       "      <td>mild_child_wasting</td>\n",
+       "      <td>state_person_time</td>\n",
+       "      <td>29</td>\n",
+       "      <td>baseline</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>covered</td>\n",
+       "      <td>late_neonatal</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>female</td>\n",
+       "      <td>2022</td>\n",
+       "      <td>mild_child_wasting</td>\n",
+       "      <td>state_person_time</td>\n",
+       "      <td>29</td>\n",
+       "      <td>baseline</td>\n",
+       "      <td>1218.859685</td>\n",
+       "      <td>uncovered</td>\n",
+       "      <td>late_neonatal</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11516</th>\n",
+       "      <td>male</td>\n",
+       "      <td>2026</td>\n",
+       "      <td>susceptible_to_child_wasting</td>\n",
+       "      <td>state_person_time</td>\n",
+       "      <td>946</td>\n",
+       "      <td>treatment_and_prevention</td>\n",
+       "      <td>63963.253936</td>\n",
+       "      <td>covered</td>\n",
+       "      <td>12_to_23_months</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11517</th>\n",
+       "      <td>male</td>\n",
+       "      <td>2026</td>\n",
+       "      <td>susceptible_to_child_wasting</td>\n",
+       "      <td>state_person_time</td>\n",
+       "      <td>946</td>\n",
+       "      <td>treatment_and_prevention</td>\n",
+       "      <td>7028.647502</td>\n",
+       "      <td>uncovered</td>\n",
+       "      <td>12_to_23_months</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11518</th>\n",
+       "      <td>male</td>\n",
+       "      <td>2026</td>\n",
+       "      <td>susceptible_to_child_wasting</td>\n",
+       "      <td>state_person_time</td>\n",
+       "      <td>946</td>\n",
+       "      <td>treatment_and_prevention</td>\n",
+       "      <td>196766.643395</td>\n",
+       "      <td>covered</td>\n",
+       "      <td>2_to_4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11519</th>\n",
+       "      <td>male</td>\n",
+       "      <td>2026</td>\n",
+       "      <td>susceptible_to_child_wasting</td>\n",
+       "      <td>state_person_time</td>\n",
+       "      <td>946</td>\n",
+       "      <td>treatment_and_prevention</td>\n",
+       "      <td>21446.917180</td>\n",
+       "      <td>uncovered</td>\n",
+       "      <td>2_to_4</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>11520 rows × 9 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          sex  year                 wasting_state            measure  \\\n",
+       "0      female  2022            mild_child_wasting  state_person_time   \n",
+       "1      female  2022            mild_child_wasting  state_person_time   \n",
+       "2      female  2022            mild_child_wasting  state_person_time   \n",
+       "3      female  2022            mild_child_wasting  state_person_time   \n",
+       "...       ...   ...                           ...                ...   \n",
+       "11516    male  2026  susceptible_to_child_wasting  state_person_time   \n",
+       "11517    male  2026  susceptible_to_child_wasting  state_person_time   \n",
+       "11518    male  2026  susceptible_to_child_wasting  state_person_time   \n",
+       "11519    male  2026  susceptible_to_child_wasting  state_person_time   \n",
+       "\n",
+       "       input_draw                  scenario          value     sq_lns  \\\n",
+       "0              29                  baseline       0.000000    covered   \n",
+       "1              29                  baseline     410.098563  uncovered   \n",
+       "2              29                  baseline       0.000000    covered   \n",
+       "3              29                  baseline    1218.859685  uncovered   \n",
+       "...           ...                       ...            ...        ...   \n",
+       "11516         946  treatment_and_prevention   63963.253936    covered   \n",
+       "11517         946  treatment_and_prevention    7028.647502  uncovered   \n",
+       "11518         946  treatment_and_prevention  196766.643395    covered   \n",
+       "11519         946  treatment_and_prevention   21446.917180  uncovered   \n",
+       "\n",
+       "                   age  \n",
+       "0       early_neonatal  \n",
+       "1       early_neonatal  \n",
+       "2        late_neonatal  \n",
+       "3        late_neonatal  \n",
+       "...                ...  \n",
+       "11516  12_to_23_months  \n",
+       "11517  12_to_23_months  \n",
+       "11518           2_to_4  \n",
+       "11519           2_to_4  \n",
+       "\n",
+       "[11520 rows x 9 columns]"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data.wasting_state_person_time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "d069a95d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>year</th>\n",
+       "      <th>sex</th>\n",
+       "      <th>age</th>\n",
+       "      <th>wasting_state</th>\n",
+       "      <th>input_draw</th>\n",
+       "      <th>scenario</th>\n",
+       "      <th>value</th>\n",
+       "      <th>numerator_measure</th>\n",
+       "      <th>denominator_measure</th>\n",
+       "      <th>multiplier</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2023</td>\n",
+       "      <td>female</td>\n",
+       "      <td>12_to_23_months</td>\n",
+       "      <td>mild_child_wasting</td>\n",
+       "      <td>29</td>\n",
+       "      <td>treatment_and_prevention</td>\n",
+       "      <td>1.037497</td>\n",
+       "      <td>wasting_prevalence_among_sqlns_covered</td>\n",
+       "      <td>wasting_prevalence_among_sqlns_uncovered</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2023</td>\n",
+       "      <td>female</td>\n",
+       "      <td>12_to_23_months</td>\n",
+       "      <td>mild_child_wasting</td>\n",
+       "      <td>223</td>\n",
+       "      <td>treatment_and_prevention</td>\n",
+       "      <td>1.055260</td>\n",
+       "      <td>wasting_prevalence_among_sqlns_covered</td>\n",
+       "      <td>wasting_prevalence_among_sqlns_uncovered</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2023</td>\n",
+       "      <td>female</td>\n",
+       "      <td>12_to_23_months</td>\n",
+       "      <td>mild_child_wasting</td>\n",
+       "      <td>232</td>\n",
+       "      <td>treatment_and_prevention</td>\n",
+       "      <td>1.077259</td>\n",
+       "      <td>wasting_prevalence_among_sqlns_covered</td>\n",
+       "      <td>wasting_prevalence_among_sqlns_uncovered</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2023</td>\n",
+       "      <td>female</td>\n",
+       "      <td>12_to_23_months</td>\n",
+       "      <td>mild_child_wasting</td>\n",
+       "      <td>357</td>\n",
+       "      <td>treatment_and_prevention</td>\n",
+       "      <td>1.061631</td>\n",
+       "      <td>wasting_prevalence_among_sqlns_covered</td>\n",
+       "      <td>wasting_prevalence_among_sqlns_uncovered</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1148</th>\n",
+       "      <td>2026</td>\n",
+       "      <td>male</td>\n",
+       "      <td>6-11_months</td>\n",
+       "      <td>susceptible_to_child_wasting</td>\n",
+       "      <td>650</td>\n",
+       "      <td>treatment_and_prevention</td>\n",
+       "      <td>1.001800</td>\n",
+       "      <td>wasting_prevalence_among_sqlns_covered</td>\n",
+       "      <td>wasting_prevalence_among_sqlns_uncovered</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1149</th>\n",
+       "      <td>2026</td>\n",
+       "      <td>male</td>\n",
+       "      <td>6-11_months</td>\n",
+       "      <td>susceptible_to_child_wasting</td>\n",
+       "      <td>680</td>\n",
+       "      <td>treatment_and_prevention</td>\n",
+       "      <td>0.994866</td>\n",
+       "      <td>wasting_prevalence_among_sqlns_covered</td>\n",
+       "      <td>wasting_prevalence_among_sqlns_uncovered</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1150</th>\n",
+       "      <td>2026</td>\n",
+       "      <td>male</td>\n",
+       "      <td>6-11_months</td>\n",
+       "      <td>susceptible_to_child_wasting</td>\n",
+       "      <td>829</td>\n",
+       "      <td>treatment_and_prevention</td>\n",
+       "      <td>1.000033</td>\n",
+       "      <td>wasting_prevalence_among_sqlns_covered</td>\n",
+       "      <td>wasting_prevalence_among_sqlns_uncovered</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1151</th>\n",
+       "      <td>2026</td>\n",
+       "      <td>male</td>\n",
+       "      <td>6-11_months</td>\n",
+       "      <td>susceptible_to_child_wasting</td>\n",
+       "      <td>946</td>\n",
+       "      <td>treatment_and_prevention</td>\n",
+       "      <td>1.003374</td>\n",
+       "      <td>wasting_prevalence_among_sqlns_covered</td>\n",
+       "      <td>wasting_prevalence_among_sqlns_uncovered</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>1152 rows × 10 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      year     sex              age                 wasting_state  input_draw  \\\n",
+       "0     2023  female  12_to_23_months            mild_child_wasting          29   \n",
+       "1     2023  female  12_to_23_months            mild_child_wasting         223   \n",
+       "2     2023  female  12_to_23_months            mild_child_wasting         232   \n",
+       "3     2023  female  12_to_23_months            mild_child_wasting         357   \n",
+       "...    ...     ...              ...                           ...         ...   \n",
+       "1148  2026    male      6-11_months  susceptible_to_child_wasting         650   \n",
+       "1149  2026    male      6-11_months  susceptible_to_child_wasting         680   \n",
+       "1150  2026    male      6-11_months  susceptible_to_child_wasting         829   \n",
+       "1151  2026    male      6-11_months  susceptible_to_child_wasting         946   \n",
+       "\n",
+       "                      scenario     value  \\\n",
+       "0     treatment_and_prevention  1.037497   \n",
+       "1     treatment_and_prevention  1.055260   \n",
+       "2     treatment_and_prevention  1.077259   \n",
+       "3     treatment_and_prevention  1.061631   \n",
+       "...                        ...       ...   \n",
+       "1148  treatment_and_prevention  1.001800   \n",
+       "1149  treatment_and_prevention  0.994866   \n",
+       "1150  treatment_and_prevention  1.000033   \n",
+       "1151  treatment_and_prevention  1.003374   \n",
+       "\n",
+       "                           numerator_measure  \\\n",
+       "0     wasting_prevalence_among_sqlns_covered   \n",
+       "1     wasting_prevalence_among_sqlns_covered   \n",
+       "2     wasting_prevalence_among_sqlns_covered   \n",
+       "3     wasting_prevalence_among_sqlns_covered   \n",
+       "...                                      ...   \n",
+       "1148  wasting_prevalence_among_sqlns_covered   \n",
+       "1149  wasting_prevalence_among_sqlns_covered   \n",
+       "1150  wasting_prevalence_among_sqlns_covered   \n",
+       "1151  wasting_prevalence_among_sqlns_covered   \n",
+       "\n",
+       "                           denominator_measure  multiplier  \n",
+       "0     wasting_prevalence_among_sqlns_uncovered           1  \n",
+       "1     wasting_prevalence_among_sqlns_uncovered           1  \n",
+       "2     wasting_prevalence_among_sqlns_uncovered           1  \n",
+       "3     wasting_prevalence_among_sqlns_uncovered           1  \n",
+       "...                                        ...         ...  \n",
+       "1148  wasting_prevalence_among_sqlns_uncovered           1  \n",
+       "1149  wasting_prevalence_among_sqlns_uncovered           1  \n",
+       "1150  wasting_prevalence_among_sqlns_uncovered           1  \n",
+       "1151  wasting_prevalence_among_sqlns_uncovered           1  \n",
+       "\n",
+       "[1152 rows x 10 columns]"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wasting_prevalence_ratio = csr.get_sqlns_risk_prevalence_ratio(data, 'wasting', stratify_by_year=True)\n",
+    "wasting_prevalence_ratio"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "cdbfc2a0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(['mild_child_wasting', 'moderate_acute_malnutrition',\n",
+       "       'severe_acute_malnutrition', 'susceptible_to_child_wasting'],\n",
+       "      dtype=object)"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wasting_prevalence_ratio.wasting_state.unique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "b639eac0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "count    288.000000\n",
+       "mean       0.873794\n",
+       "std        0.024876\n",
+       "min        0.816764\n",
+       "2.5%       0.832422\n",
+       "50%        0.871739\n",
+       "97.5%      0.924453\n",
+       "max        0.939889\n",
+       "Name: value, dtype: float64"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wasting_prevalence_ratio.query(\n",
+    "    \"wasting_state == 'moderate_acute_malnutrition'\").value.describe(percentiles=[.025, .975])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "3088eb5f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZQAAAEWCAYAAABBvWFzAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAA3J0lEQVR4nO3de7ylY/3/8dfbKczJKTunGol8ZVAm0oE9ilAoKeQwI+WrA/LT8du3mkqlAwohhUEYUUpSTJhIlBmMccxp1AxGTjOz8ZXh8/vjutbMPctaa99777XW3mt7Px+P9Vj34brv+3Ot07Xu67rv61JEYGZmNlDLDXYAZmY2PLhAMTOzpnCBYmZmTeECxczMmsIFipmZNYULFDMzawoXKGZVJE2RdMxgx9Eqkt4l6Z4W7v8Pkia2av82dLlAsSUkzZH0H0lrVS2/RVJIGlu1fHJevm3V8kl5+QlVy/fMy6fUOX63pJck9UhaJOkeSQc3J3edK7/OL+TX5WlJf5W0XR+2D0lvqMxHxHUR8cZ+xjJd0serlnVLmlvY/64RcXZf47LO5wLFqj0I7FeZkTQOWLU6kSQBBwFP5udq9wMfkbRCYdlE4B+9HP/hiBgJjAa+CPxM0mY1jr/Cy7Yc3i7Mr8tawDXARYMcz5D2Cvx8DAkuUKzauSxbQEwEzqmR7l3AOsARwL6SVqpa/ygwG3gvgKQ1gLcDl5YJIpLfAE8Bm+WznuslnSDpCWCypFdJ+qGkf0qaL+k0Savk490l6f2V/UlaQdK/Jb0lz18k6VFJCyRdK+lN9WKR9H5JtxbODrYorJsj6XOSbsv7ulDSyoX1e+ZtF0q6X9IuefkYSWdIekTSPEnHSFq+xOuyGDgPWE/Sq/O+tpF0Q47vEUknV94PSdfmTWflM5x9qs8oJP1XPvN4WtIdkvbo9Q1qoHgWI+kNkv6cX5vHJV1YL668/BOS7pP0pKRLJa1b2O/O+ax1gaRT8n4rx6n1+dhI0tWSnsjHPk/SaoX9zZH0+fzePZPfjy6lKrtFkv4kafWBvBavNC5QrNqNwOj8I7M8sC/wixrpJgK/A36Z53evkeYclhZO+wK/BZ4vE4Sk5SR9EFiNVDABbAs8AHQB3waOBTYBtgLeAKwHfC2nvYDCmRapYHs8Im7O838ANgbWBm4m/UjXiuPNwJnAfwNrAj8FLpX0qkKyjwC7ABsCWwCT8rbb5Nfg8zkf2wNz8jZTgMU57jcDOwPLVCXViWcl0mv6BKmwBXgROIp09rId8G7gUwARsX1Os2VEjIyIC6v2tyLpfbwyvxaHA+dJ6leVWA3fyvteHVgfOKleXJJ2BL5Lej3XAR4CpuY41wIuBr5Meh/uIf1BKar+fCjvb13gv4ANgMlV23wI2In0Odqd9Ln4H+DVpN/HIwaY/1eWiPDDDyIC0o/de4D/JX0RdwGmASsAAYzN6VYFFgIfyPM/BX5b2M8k4C/AKsB8YAypoHoHcAwwpc7xu4GXgKdJVWm3AvsW9vnPQloBzwAbFZZtBzyYp98ALAJWzfPnAV+rc9zVcv7G5PkpwDF5+lTgW1Xp7wF2KLxmBxTWfR84rfC6nFDjeF2kgnWVwrL9gGvqxDcZ+E9+XV4kFSbdDd7HzwKXFOYDeEPV6zw3T7+LdDa5XGH9BcDkOvueDjybY6k8eir7K6T5eJ4+BzgdWL/GvqrjOgP4fmF+JPACMJZUiN5Q9f7/q3CcZT4fdWL/AHBL1ed9/8L8r4BTC/OHA78Z7O9lJz18hmK1nAt8lPQlrVXd9UHSv+vL8/x5wK6VKpiKiHgO+D2pgFozIq4vceyHI2K1iFgjIraKiKmFdf8qTL+aVLDNzFU1TwN/zMuJiPuAu4DdJa0K7AGcDyBpeUnH5iqohSw9a1jmYoTsdcDRlWPk42xA+tdb8Whh+lnSDyE53f119rki8Ehhnz8lnSHU88uIWI1UGN0ObF1ZIWkTSZflKryFwHfq5KWWdYF/RcRLhWUPkc726jkiv0er5Zje3yDtF0g//n/P1Wkf6yWWhyozEdFDKjzXq8RZWBfA3Krti58PcvXV1FyluJB0pl39uswvTD9XY34kVpoLFHuZiHiI1Di/G/DrGkkmkr5o/5T0KKmBeEVSIVTtHOBoaleb9Tm0wvTjpC/8mwo/bmMiNVxXVKq99gTuzIUMOc49SWdjY0j/gCH98FX7F/Dt4g9oRKwaEReUiPdfwEZ1lj8PrFXY5+iIqNuOUxERjwOHktoI1smLTwXuBjaOiNGkKptaeanlYWADScXfgtcC80pu31u8j0bEJyJiXVK14Smqf2XXw6TCFgBJI0jVW/OAR0hVZpV1Ks5XDlc1/528bFx+XQ6g/Oti/eACxeo5BNgxIp4pLpS0HqmO/v2ktoutgC2B71H7aq8/k+qoT2pmcPkf9c+AEyStXYlN0nsLyaaS2iY+ST47yUaRftCfIJ3lfKfBoX4GHCZpWyUjJL1P0qgSYZ4BHCzp3blNaD1Jm0bEI6R2heMkjc7rNpK0Q8m83wNcQfr3X8nPQqBH0qY5v0XzgdfX2d3fSGdVX5C0oqRuUlvC1Drp+0TShyVVfvifIv3AV86GquO6gPR6bZXbqL4D/C0i5pDOdMdJ+oDSFVyfBl7Ty+FHkarjFuTP7eebkSerzwWK1RQR90fEjBqrDgRujYgr87/PRyPiUeBEYAtJm1ftJyLiqoh4sgVhfhG4D7gxV2n8CVjSmJx/uG8gNd4WG6PPIVWtzAPuJLXv1JRfg08AJ5N+EO8jN7r3JiL+DhwMnAAsIBWulX/gBwEr5eM/RWpwXqfGbur5AXBoLkw/RzrrWkQqAC+sSjsZODtXr32kKsb/kAqQXUlnfacAB0XE3X2IpZG3An+T1EO6wu/IiHigVlwR8Sfgq6S2jEdIZ3f75jgfBz5MaqN6AtgMmEHjizy+AbyF9Nr/ntpn29ZESlWRZmadI1fRzSU1ql8z2PFY4jMUM+sIkt4rabVcHVZpJ6p7dmnt5wLFzDrFdqSr5h4nVdN9IF9JaEOEq7zMzKwpfIZiZmZN8YrtQG2ttdaKsWPHtmTfzzzzDCNGjGjJvttpOORjOOQBhkc+hkMeYHjkYyB5mDlz5uMR8epa616xBcrYsWOZMaPWVbEDN336dLq7u1uy73YaDvkYDnmA4ZGP4ZAHGB75GEgeJD1Ub52rvMzMrClcoJiZWVO4QDEzs6ZwgWJmZk3Ra4Ei6R25108kHSDpeEmv6207MzN7ZSlzhnIq8KykLUndkN9P7TEyzMzsFaxMgbI4D2azJ3ByRPyE1C20mZnZEmXuQ1kk6cukwWm2z718rtjasMzMrNOUOUPZhzTmwCF53Iv1SWMxmJmZLdHrGUouRI4vzP8Tt6FYG4390u/7ve2UXTq7iwyzTlLmKq+9JN0raYGkhZIW5dHxzMzMlijThvJ9YPeIuKvVwZiZWecqU6DMb0dhIulM4P3AYxGxeV52IUvHCF8NeDoitqqx7RzSeNovkq5KG9/qeM3MbFllCpQZ+Yf9N6TGeQAi4tdNjmUKcDKF9pmI2KcyLek4YEGD7SdExONNjsnMzEoqU6CMBp4Fdi4sC6CpBUpEXCtpbK11kgR8BNixmcc0M7PmGVJDAOcC5bJKlVdh+fbA8fWqsiQ9CDxFKuh+GhGn10l3KHAoQFdX19ZTp05tYvRL9fT0MHLkyJbsu52alY/Z8xqdWLbWhmOW93sxRAyHPMDwyMdA8jBhwoSZ9X6Lez1DkbQ+cBLwjrzoOuDIiJjbr2j6Zz/gggbr3xkR8yStDUyTdHdEXFudKBc0pwOMHz8+WjVIznAYgAeal49JA7jsd6Cm7DLC78UQMRzyAMMjH63KQ5kbG88CLgXWzY/f5WVtIWkFYC/gwnppImJefn4MuATYpj3RmZlZRZkC5dURcVZELM6PKUDN8YRb5D3A3fXOiCSNkDSqMk1q67m9jfGZmRnlCpQncrf1y+fHAcATzQ5E0gXADcAbJc2VdEhetS9V1V2S1pV0eZ7tAv4iaRbwd+D3EfHHZsdnZmaNlbnK62OkNpQTSI3efwUObnYgEbFfneWTaix7GNgtTz8AbNnseMzMrG/K9OX1ELBHG2IxM7MOVrdAkfSFiPi+pJNIZybLiIgjWhqZmZl1lEZnKJXuVma0IxAzM+tsdQuUiPhdnnw2Ii4qrpP04ZZGZWZmHafMVV5fLrnMzMxewRq1oexKupJqPUknFlaNBha3OjAzM+ssjdpQHia1n+wBzCwsXwQc1cqgzMys8zRqQ5kFzJJ0fkS80MaYzMysA5W5sXGspO8CmwErVxZGxOtbFpWZmXWcsp1DnkpqN5lAGgDrF60MyszMOk+ZAmWViLiKNHbKQxExGXhfa8MyM7NOU6bK63lJywH3SvoMMA/o7NFlzMys6cqcoRwJrAocAWwNHAhMbGVQZmbWecp0DnlTnuyhBb0Mm5nZ8FBmCOBNgM8Dryumj4gdWxiXmfXT2AEMuTznWDePWv+VaUO5CDgN+BnwYmvDMTOzTlWmQFkcEae2PBIzM+toZRrlfyfpU5LWkbRG5dHyyMzMrKOUOUOpXNH1+cKyAHynvJmZLVHmKq8N2xGImZl1trpVXpJ2zM971Xo0OxBJZ0p6TNLthWWTJc2TdGt+7FZn210k3SPpPklfanZsZmbWu0ZnKDsAVwO711gXwK+bHMsU4GRSX2FFJ0TED+ttJGl54CfATsBc4CZJl0bEnU2Oz8zMGmjUff3X83NbbmaMiGslje3HptsA90XEAwCSpgJ7Ai5QzMzaSBHROIG0JvB14J2kM5O/AN+MiCeaHkwqUC6LiM3z/GRgErCQNNjX0RHxVNU2ewO7RMTH8/yBwLYR8Zka+z8UOBSgq6tr66lTpzY7CwD09PQwcmTnd3fWrHzMnregCdH0z4Zjln/FvRcDeb3HrTem39v2xt+LoWMgeZgwYcLMiBhfa12Zq7ymAtcCH8rz+wMXAu/pVzR9cyrwLVJB9i3gOOBj/d1ZRJwOnA4wfvz46O7ubkKILzd9+nRate92alY+Jg3gzu2BmrLLiFfcezGQ13vO/uWO0R/+XgwdrcpDmftQ1omIb0XEg/lxDNDV9EhqiIj5EfFiRLxEulN/mxrJ5gEbFObXz8vMzKyNyhQoV0raV9Jy+fER4IpWBwYgaZ3C7AeB22skuwnYWNKGklYC9gUubUd8Zma2VN0qL0mLSFVNAj7L0lEalyP1PPy5BtuuDqwLPAfMyWcYDUm6AOgG1pI0l9Ru0y1pqxzHHOC/c9p1gZ9HxG4RsTiP03IFsDxwZkTc0dvxzMysuRpd5TWqLzuSNAb4NLAfsBLwb9IY9F2SbgROiYhrGhxvvxqLz6iT9mFgt8L85cDlfYnXzMyaq0yjPJK2AMaybPf11fehXEy6h+RdEfF01fZbAwdKen1E1CwkzMyss5UZD+VMYAvgDqBSdfWyGxsjYqd6+4iImcDM/odpZmZDXZkzlLdFxGZldyjpF8Cfgesi4u5+R2ZmZh2lzFVeN0gqXaCQ2j3WAU6S9ICkX0k6sn/hmZlZpyhzhnIOqVB5FHiedNVXRMQWtRJHxDWSrgXeCkwADgPeBPy4OSGbDX0DGYYXPBSvdaYyBcoZwIHAbJa2odQl6SpgBHADcB3w1oh4bCBBmpnZ0FemQPl3RPTlRsHbgK2BzYEFwNOSboiI5/oToJmZdYYyBcotks4Hfkeq8gJqXjZcWX4UgKRRpI4dzwJeA7xqoMGamdnQVaZAWYVUkOxcWFZ3PJR81/q7SGcpc4AzSVVfZmY2jJUZAriv46GsDBwPzIyIxf2KyszMOk6ZGxvXB04C3pEXXQccGRFza6WvjK4oaW1JKxeW/3Pg4Zq1z0Cv1DJ7pSlzH8pZpN57182P3+VlNUnaXdK9wIOkGxznAH8YcKRmZjaklSlQXh0RZ0XE4vyYAry6QfpjgLcB/4iIDYF3AzcOPFQzMxvKyhQoT0g6QNLy+XEA0Gj43xfy8MDLSVou9zBcc7hIMzMbPspc5fUxUhvKCaSru/4KNGqof1rSSNKwwedJegx4ZqCBmpnZ0FbmKq+HgD36sM89SQNrHUUaf34M8M1+RWdmZh2j1yovSWdLWq0wv3ru0r5W2uWByyLipdzecnZEnJirwMzMbBgr04ayRXHArIh4CnhzrYQR8SLwUh690czMXkHKtKEsJ2n1XJAgaY1etusBZkuaRqHtJCKOGFCkZmY2pJUpUI4jdV9/UZ7/MPDtBul/TZ1uWRrJ1WjvBx6LiM3zsh8AuwP/Ae4HDq4eXjinmwMsAl4EFkeEryozM2uzMo3y50iaAeyYF+0VEXc2SH92P2OZApxMGn+lYhrw5YhYLOl7wJeBL9bZfkJEPN7PY5uZ2QCVOUMhFyB1CxEASbNJlxXX20fNAbkK66+VNLZq2ZWF2RuBvXsN1szMBoUi6pYBfduR9Lo8+en8fG5+PoA0wuOXSuxjLOkqsc1rrPsdcGFE/KLGugeBp0gF2k8j4vQ6+z8UOBSgq6tr66lTp/YWUr/09PQwcuTIluy7nZqVj9nzFjQhmv7ZcMzy/c7DYMY9br1lr2vpy3sxkLirj9tM/l4MHQPJw4QJE2bWa1ZoWoGyZIfSLRHx5qplN0fEW0psO5YaBYqkr5Dutt8ragQsab2ImCdpbVI12eERcW2jY40fPz5mzJjRe4b6Yfr06XR3d7dk3+3UrHwMZieLU3YZ0e88DGbc1UMA9+W9GEjcrRx62N+LoWMgeZBUt0BpeNmwpBUK0yMljc9XefWymd5RmHl7b8fpZWeTSI31+9cqTAAiYl5+fgy4BNimv8czM7P+qftDn3/I50v6h6RdSUP7fg+YJWm/Bvs8BDhF0px89dUppO5b+kzSLsAXgD0i4tk6aUbk0SGRNII0ENjt/TmemZn1X6NG+aOBNwKjgFnAmyPifkldpGqlC2ptFBEzgS0rNzdGRKkKXUkXAN3AWpLmAl8nXdX1KmCaJIAbI+IwSesCP4+I3YAu4JK8fgXg/Ij4Y5ljmplZ8zQqUF7Ml+E+LqknIu4HiIj5+ce7obIFSSF9rbOeM+qkfRjYLU8/AGzZl2OZmVnzNSpQ/inpu6QzlLslHUe6YfE9wCPtCM7MzDpHo8byA4CFwFxSb8M3kKqguoBJLY/MzMw6St0zlIhYCHy3sOji/OgTSeOBh3M1lZmZDVONrvIaL+kaSb+QtIGkaZKelnSTpJq9DddxOPB7SRcOPFwzMxuqGrWhnEK60mo10iiNR0XETpLenddtV+YAETERoHJpr5mZDU+N2lBWjIg/RMQFpK5TLiZNXAWsXG8jJQdI+lqef62kbSJiUVMjNzOzIaVRgfJ/knaW9GEgJH0AQNIOpG7i66mcvVQuA14E/KQJsZqZ2RDWqMrrMOD7wEvAe4FPSpoCzCN3sFjHthHxFkm3QBrhUdJKTYrXzMyGqEZXec0iFSQVR+ZHb17IY8sHgKRXkwol62CD2VGimXWG3jqH3FTSuyWNrFq+S4PNTiR10Li2pG8DfwG+M+BIzcxsSGt02fARwG9Jl/3eLmnPwuq6BUREnEfq0PG7pDvqPxARF9VLb2Zmw0OjNpRPAFtHRE8ep+RiSWMj4sdA3c68cvf2j1HoPFLSihHxQpNiNjOzIahRgbJcRPQARMQcSd2kQuV1NChQgJuBDUgjKIp0H8ujkuYDn8i9EZuZ2TDTqA1lvqStKjO5cHk/sBYwrsF204DdImKtiFgT2BW4DPgU6ZJiMzMbhhoVKAcBjxYXRMTiiDgI2L7Bdm+LiCsK21wJbBcRN5LGNjEzs2Go0WXDcxusu77BPh+R9EVgap7fh3S2szy+fNjabPa8BUzyJc9t0dul5UePW1z3vWjlWPbWPv0e672BjwLrA7/Jj9fmZcsDH2nB8czMbAho1CjfL3mUx8PrrL6v2cczM7OhoWGBkqup/hQRE8ruMN8Z/wXgTRQ6kYyIHfsbpJmZDX0Nq7wi4kXgJUlj+rDP84C7gQ2BbwBzgJv6G6CZmXWGMm0oPcBsSWdIOrHyaJB+zYg4A3ghIv4cER8Dej07kXSmpMck3V5YtkYe2Ove/Lx6nW0n5jT3SppYIk9mZtZkZQqUXwNfBa4FZhYe9VTuiH9E0vvy6I5rlDjOFKC6j7AvAVdFxMbAVXl+GfnO/K8D2wLbAF+vV/CYmVnr9NooHxFnS1oFeG1E3FNin8fkKrKjgZOA0cBRJY5zbe7ipWhPoDtPnw1MB75Ylea9wLSIeBJA0jRSwXQBZmbWNoqIxgmk3YEfAitFxIb57vlvRsQeTQ8mFSiXRcTmef7piFgtTwt4qjJf2OZzwMoRcUye/yrwXET8sMb+DyWP5dLV1bX11KlTq5M0RU9PDyNHjuw94RBXzMfseQsGOZr+6VoF5j832FH03bj1lm227MtnaiDvVfVx+6K34zZ6LwZy3HYbDt/vgeRhwoQJMyNifK11ZS4bnkyqSpoOEBG3Snp9vyIZgIgISY1Lv973cTpwOsD48eOju7u7GaG9zPTp02nVvtupmI9OvTnw6HGLOW5206+Ob7k5+3cvM9+Xz9RA3qvq4/ZFb8dt9F4M5LjtNhy+363KQ5k2lBciovqvR7vueJ8vaR2A/PxYjTTzSJ1RVqyfl5mZWRuVKVDukPRRYHlJG0s6Cfhri+OquBSoXLU1kTQ+S7UrgJ0lrZ4b43fOy8zMrI3KFCiHk25SfB44H1gAfLbsASTtKWnbEukuAG4A3ihprqRDgGOBnSTdC7wnzyNpvKSfA+TG+G+R7nW5idS+82TZ+MzMrDnKVC5vGhFfAb7Sz2NsC4yTtEJE7FovUUTsV2fVu2uknQF8vDB/JnBmP+Mzs6y3Dh7NGilToBwn6TXAxcCFEXF7bxsURcT/9CsyMzPrKL1WeeV+vCYA/wZ+Kmm2pP+tl17StyStUJgfLemspkRrZmZDVqnu6yPi0Yg4ETgMuBX4WoPkKwB/k7SFpJ1I7Roe9tfMbJjrtcpL0n+RBsnaG3gcuJB0F3xNEfFlSX8C/kYaV377iHC39WZmw1yZNpQzSaMv7hwRD/eWWNL2wInAN0ljz58k6ZAy25qZWecq05fXdpJWAjbJHTHeExEvNNjkh8CHI+JOAEl7AVcDmzYjYLNXguqrrRoNn2s2VJSp8toBOIc0romADSRNjIhr62yyXR5HBYCI+LWkPzcjWDMzG7rKNMofT6ru2iEitif17ntCg/QbSbqqMq6JpC2ATw48VDMzG8rKFCgrFrutj4h/ACs2SP8z4MvkcVEi4jZg34EEaWZmQ1+ZRvkZuZuTX+T5/YEZDdKvGhF/T73NL7G4n/GZmVmHKFOgfBL4NHBEnr8OOKVB+sclbQQEgKS9gUcGEqSZmQ19Za7yep7UjnJ8yX1+mjTmyKaS5gEPAgf0O0IzM+sITR95KCIeAN4jaQSwXEQsavYxzMxs6CnV9UpfSDpS0mjgWeAESTdL2rnZxzEzs6Gl1wJF0rg+7vNjEbGQNNDVmsCB5HFMzMxs+CpzhnKKpL9L+pSkMSXSVy7v2g04JyLuKCwzM7Nhqkz39e8iXSq8ATBT0vm5F+F6Zkq6klSgXCFpFO0bg97MzAZJqUb5iLg3j4Eyg9Tx45uVbjT5n4j4dVXyQ4CtgAci4llJawIHNzFmMzMbgsr05bUFqUB4HzAN2D0ibpa0LmkM+GUKlIh4Cbi5MP8E8EQzgzYzs6GnzBnKScDPSWcjz1UWRsTDjUZuNDOzV5YyjfKXRMS5xcJE0pEAEXFuyyJbeqw3Srq18Fgo6bNVabolLSikaTSipJmZtUCZM5SDgB9VLZsE/LjZwdSSO6bcCkDS8sA84JIaSa+LiPe3IyYzM3u5ugWKpP2AjwIbSrq0sGoU8GTZA0i6K0/+JCJO7leUS70buD8iHhrgfszMrMkUEbVXSK8DNgS+C3ypsGoRcFtElO5BOF/p9baIGNCQc5LOBG6uLpgkdQO/AuYCDwOfy/e/VG9/KHAoQFdX19ZTp04dSDh19fT0MHLkyJbsu52K+Zg9b8EgR9M/XavA/Od6TzfUDYd8NMrDuPXK3OI2NAyH7/dA8jBhwoSZETG+1rq6BUp/5CqpP0XEhKbtdOm+VyIVFm+KiPlV60YDL0VEj6TdgB9HxMaN9jd+/PiYMaNRL/z9N336dLq7u1uy73Yq5qN6SNpOcfS4xRw3u+ld1rXdcMhHozzMOfZ9bY6m/4bD93sgeZBUt0Cp2ygv6S/5eVFuCK88FklaWGubPPTvSyXvqO+rXUlnJ/OrV0TEwojoydOXAytKWqsFMZiZWR11//JExDvz86g+7rMHmC1pGvBMYX9H1N+klP2AC2qtkPQaYH5EhKRtSAWl730xM2ujMjc2bgTMjYjnc1vFFqQ+up6us8mvqbrZcaByV/g7Af9dWHYYQEScBuwNfFLSYuA5YN9oZl2emZn1qkyl7K+A8ZLeQBo467fA+aS+ul4mIs5uXnhL9vkMqefi4rLTCtMnAwO9gszMzAagTIHyUkQslvRB4KSIOEnSLfUSS9qYdGXYZsDKleUR8foBR2tmZkNWmTvlX8j3pEwELsvLVmyQ/izgVGAxMAE4B/jFQII0M7Ohr8wZysHAYcC3I+JBSRsCjbpcWSUirpKkfAPiZEkzAXeHYmY1DfSy9E667Hg467VAiYg7gSMK8w8C32uwyfOSlgPulfQZUlcpnX0XkJmZ9arMEMDvkDRN0j8kPSDpQUkPNNjkSGBVUiG0NXAAqbrMzMyGsTJVXmcARwEzgRd7SxwRNwFIeikiPLCWmdkrRJlG+QUR8YeIeCwinqg86iWWtJ2kO4G78/yWkk5pVsBmZjY0lTlDuUbSD0g3Kz5fWRgRN9dJ/yPgvcClOd0sSdsPME4zMxviyhQo2+bnYmdgAexYb4OI+Fcacn6JXqvKzMyss5W5yquvPQf/S9LbgZC0IqmR/q5etjEzsw5X5iqvLklnSPpDnt9M0iENNjkM+DSwHumS4a3yvJmZDWNlGuWnAFcA6+b5fwCfbZA+ImL/iOiKiLUj4oBGjfhmZjY8lClQ1oqIXwIvAeSRGhu1idwo6SJJu6qqIcXMzIavMgXKM3kI3wCQ9Dag0Xiwm5B6JT6IdLf8dyRtMuBIzcxsSCtzldf/I10CvJGk64FXk8YfqSmPQzINmCZpAqljyE9JmgV8KSJuGHjYZmY21JS5yutmSTsAbwQE3BMRL9RLn89mDgAOBOYDh5MKpK2Ai4ANBx62mZkNNXULFEl71Vm1iSQiot6ojDeQeiP+QETMLSyfIem0OtuYmVmHa3SGsnt+Xht4O3B1np8A/JX6w/y+sd7wuxHRqJdiMzPrYHULlErHjpKuBDaLiEfy/DqkS4mXIelnwIkRMbvGuhHAPsDzEXFec0I3M7OhpEyj/AaVwiSbD7y2RrqfAF+VNA64Hfg3aQjgjYHRwJlAvwoTSXOARaTLlRdHxPiq9QJ+TBrn/llgUoO+xszMrAXKFChXSboCuCDP7wP8qTpRRNwKfETSSFK/X+sAzwF3RcQ9TYh1QkQ8XmfdrqSCa2NS32OnsrQPMjMza4MyV3l9RtIHgUqPwadHxCUN0vcA05sTXml7AufktpsbJa0maZ2qMyszM2sh1Wk/H1IkPQg8Rbq58qcRcXrV+suAYyPiL3n+KuCLETGjKt2hwKEAXV1dW0+dOrUl8fb09DBy5NAb9Xj2vEb3o75c1yow/7kWBdMmwyEPMDzyMVTzMG69MX1KP1S/330xkDxMmDBhZnWzQ0WZKq+h4J0RMU/S2qQbJu+OiGv7upNcEJ0OMH78+Oju7m5ymMn06dNp1b4HYtKXft+n9EePW8xxszvlI1LbcMgDDI98DNU8zNm/u0/ph+r3uy9alYcyXa+UIunc/Hxks/ZZERHz8vNjwCXANlVJ5gEbFObXz8vMzKxNynRfv7ukMgXP1pLWBT4maXVJaxQf/Q1Q0ghJoyrTwM6kq8iKLgUOUvI20rDFbj8xM2ujMuef+wA/kvQr4MyIuLtOutOAq4DXAzNJ3bRURF7eH13AJbnj4hWA8yPij5IOA4iI04DLSZcM30e6bPjgfh7LzMz6qcxVXgdIGg3sB0yRFMBZwAURsaiQ7kTgREmnRsQnmxVgRDwAbFlj+WmF6cCDeJmZDapSbSgRsRC4GJhKur/kg8DNkg6vkfaTkraU9Jn82KKpEZuZ2ZBUpg1lT0mXkO4tWRHYJiJ2JZ01HF0j/RGkO+LXzo/zahU8ZmY2vJRpQ9kLOKH6Mt2IeLbO2PIfB7aNiGcAJH2P1APxSQMN1szMhq4yVV6PVhcmuZAgIq6qkV4sO0TwiyzbQG9mZsNQmQJlpxrLdm2Q/izgb5ImS5oM3Aic0Y/YzMysgzQaYOuTwKdIQ//eVlg1Cri+3nYRcbyk6cA786KDI+KWJsRqZmZDWKM2lPOBPwDfBb5UWL4oIp5stNPcdby7jzczewVpVKBERMyR9LL7OySt0VuhYq0xto/9cZmZtUtvZyjvJ931HjTvznczMxuGGg0B/P78vGH7wjEzs07VqFH+LY029BC7ZmZW1KjK67gG6wLYscmxmJlZB2tU5TWhnYGYmVlna1TltWNEXC1pr1rrI+LXrQvLzKw9+nrl5NHjFi8Z/XTOse9rRUgdq1GV1w7A1cDuNdYF4ALFzMyWaFTl9fX87MGqzMysV2W6r19T0omSbpY0U9KPJa3ZjuDMzKxzlOkccirwb+BDwN55+sJWBmVmZp2nzHgo60TEtwrzx0jap1UBmZlZZypToFwpaV/gl3l+b+CK1oVkZtYZBtK33nC8QqxulZekRZIWAp8g9ev1n/yYChzanvBA0gaSrpF0p6Q7JB1ZI023pAWSbs2Pr7UrPjMzSxpd5TWqnYE0sBg4OiJuljQKmClpWkTcWZXuukr/Y2Zm1n5lqryQtDqwMbByZVn1sMCtEhGPAI/k6UWS7gLWA6oLFDMzG0SKiMYJpI8DRwLrA7cCbwNuiIi29+UlaSxwLbB5RCwsLO8GfgXMBR4GPhcRd9TY/lBydV1XV9fWU6dObUmcPT09jBw5siX7nj1vQUv2W0vXKjD/ubYdriWGQx5geORjOOQBmpePceuNGfhO+mkgv1ETJkyYGRHja60rU6DMBt4K3BgRW0naFPhORNTskqVVJI0E/gx8u7rbF0mjgZciokfSbsCPI2LjRvsbP358zJgxoyWxTp8+ne7u7pbsu50DbB09bjHHzS51EjtkDYc8wPDIx3DIAzQvH4PZKD+Q3yhJdQuUMveh/F9E/F/e0asi4m7gjf2KpJ8krUg6AzmvVh9iEbEwInry9OXAipLWameMZmavdGWK2bmSVgN+A0yT9BTwUCuDKpIk4Azgrog4vk6a1wDzIyIkbUMqKJ9oV4xmZu02kNqKKbuMaGIkS/VaoETEB/PkZEnXAGOAP7YkmtreARwIzJZ0a172P8Brc3ynke6N+aSkxcBzwL7RW12emZk1VdmrvN4CvJPUy/D1EfGflkZVEBF/Ydnx7GulORk4uT0RmZlZLWU6h/wacDawJrAWcJak/211YGZm1lnKnKHsD2xZaJg/lnT58DEtjMvMzDpMmau8HqZwQyPwKmBea8IxM7NO1WgI4JNIbSYLgDskTcvzOwF/b094ZmbWKRpVeVXu+psJXFJYPr1l0ZiZWcdq1Dnk2ZVpSSsBm+TZeyLihVYHZmZmnaXXRvncT9bZwBzS5bsbSJrYrs4hzcysM5S5yus4YOeIuAdA0ibABcDWrQzMzMw6S5mrvFasFCYAEfEPYMXWhWRmZp2ozBnKTEk/B36R5/dnaYO9mZkZUK5AOQz4NHBEnr8OOKVlEXWA3jplO3rcYia1sZt5M7OhoGGBIml5YFZEbArU7OnXzMwMemlDiYgXgXskvbZN8ZiZWYcqU+W1OulO+b8Dz1QWRsQeLYvKzMw6TpkC5astj8LMzDpeo768ViY1yL8BmA2cERGL2xWYmZl1lkZnKGcDL5Cu6toV2Aw4sh1BmZkNdwMZwneoalSgbBYR4wAknYF7GDYzswYaXeW1pANIV3WZmVlvGp2hbClpYZ4WsEqeFxARMbrl0ZmZWceoe4YSEctHxOj8GBURKxSm21qYSNpF0j2S7pP0pRrrXyXpwrz+b5LGtjM+MzMr1znkoMp36/+EpRcG7Cdps6pkhwBPRcQbgBOA77U3SjMzG/IFCrANcF9EPBAR/wGmAntWpdmTdFUawMXAuyWpjTGamb3iKSIGO4aGJO0N7BIRH8/zBwLbRsRnCmluz2nm5vn7c5rHq/Z1KHBonn0jcA+tsRbweK+phr7hkI/hkAcYHvkYDnmA4ZGPgeThdRHx6lorytwpP2xExOnA6a0+jqQZETG+1cdpteGQj+GQBxge+RgOeYDhkY9W5aETqrzmARsU5tfPy2qmkbQCMAZ4oi3RmZkZ0BkFyk3AxpI2lLQSsC9waVWaS4GJeXpv4OoY6nV5ZmbDzJCv8oqIxZI+A1wBLA+cGRF3SPomMCMiLgXOAM6VdB/wJKnQGUwtr1Zrk+GQj+GQBxge+RgOeYDhkY+W5GHIN8qbmVln6IQqLzMz6wAuUMzMrClcoPRRiW5gXivpGkm3SLpN0m55+U6SZkqanZ93bH/0S2LsVx6q1vdI+lz7on65geRD0haSbpB0R35PVm5v9Evi6O/naUVJZ+fY75L05fZHv0ycveXjdZKuynmYLmn9wrqJku7Nj4nV27ZLf/MgaavCZ+k2Sfu0P/pl4uz3e5HXj5Y0V9LJfT54RPhR8kG6KOB+4PXASsAsUjf/xTSnA5/M05sBc/L0m4F18/TmwLxOy0Nh/cXARcDnOvS9WAG4Ddgyz68JLN9hefgoMDVPrwrMAcYO4ffiImBint4RODdPrwE8kJ9Xz9Ord1geNgE2ztPrAo8Aq3Xae1FY/2PgfODkvh7fZyh9U6YbmAAqnWeOAR4GiIhbIuLhvPwOUu/Nr2pDzNX6nQcASR8AHiTlYTANJB87A7dFxCyAiHgiIl5sQ8zVBpKHAEbk+65WAf4DLGRwlMnHZsDVefqawvr3AtMi4smIeAqYBuzShpir9TsPEfGPiLg3Tz8MPAbUvJO8DQbyXiBpa6ALuLI/B3eB0jfrAf8qzM/Ny4omAwdImgtcDhxeYz8fAm6OiOdbEWQv+p0HSSOBLwLfaH2YvRrIe7EJEJKukHSzpC+0Otg6BpKHi4FnSP+G/wn8MCKebGm09ZXJxyxgrzz9QWCUpDVLbtsOA8nDEpK2IZ0Z3N+iOHvT73xIWg44Duh3VbYLlObbD5gSEesDu5Huj1nyOkt6E6k35P8epPjKqJeHycAJEdEzmMH1Qb18rAC8E9g/P39Q0rsHL8yG6uVhG+BFUhXLhsDRkl4/eGH26nPADpJuAXYg9W4xGGeFA9EwD5LWAc4FDo6IlwYnxFLq5eNTwOWR+0TsjyF/Y+MQU6YbmEPIp+wRcUNu7F0LeCw3fl0CHBQRg/UPZiB52BbYW9L3gdWAlyT9X0T0vfFu4AaSj7nAtZE7D5V0OfAW4KpWB11lIHn4KPDHiHiB9Nm6HhhPaoNot17zkauC9oIlZ7ofioinJc0Duqu2nd7KYOvodx7y/Gjg98BXIuLGdgRcx0Dei+2Ad0n6FDASWElST0S8rGG/rsFoOOrUB6kAfoD0j7DS4PWmqjR/ACbl6f8i1XmL9AM8C9irU/NQlWYyg9soP5D3YnXgZlJj9grAn4D3dVgevgiclZePAO4EthjC78VawHJ5+tvAN/P0GqQ2udXz40FgjQ7Lw0qkPyOfHYzXv1n5qEoziX40yg9q5jvxQap2+AepjvQredk3gT3y9GbA9fmNvBXYOS//X1Kd962Fx9qdlIeqfUxmEAuUgeYDOIB0YcHtwPc7LQ+kf5AX5TzcCXx+iL8XewP35jQ/B15V2PZjwH35cXCn5SF/ll6o+m5v1Wn5qNrHJPpRoLjrFTMzawo3ypuZWVO4QDEzs6ZwgWJmZk3hAsXMzJrCBYqZmTWFC5Q2kxSSflGYX0HSvyVdVpXuN5JurFo2OW//hsKyz+Zl41sffWM5vkHtgbgRSWMlfbQwP17SiX3cxwW5l9aj+hlDl6TLJM2SdGe+qbKy7k2Srs49xd4v6RuVXhYkTarV+6ukOZJ+VZjfW9KU3o411EnqlN4YBk3uKXjQv/dFLlDa7xlgc0mr5PmdqLqTVdJqwNbAmBrdacxm2SGOP8wAOmrMnQsOG73kZyzpDnMAImJGRBzRh32/BnhrRGwRESf0M55vkjpD3DIiNgO+lNOtAlwKHBsRbwTGkbpXObLEYbaWtFmN5TWPNViG22etFTr9NXKBMjguB96Xp/cDLqhavxfwO1JPoftWrfsNuXdQSRsBC4DHax0k/3v9vtKYGX+vnNlImiLpNEl/A74vaSNJf1Qap+U6SZtKGiPpocI/5BGS/qU0DscnJN2U//n+StKqNY79sn0Wjn2ipL9KekDS3oVtvphjnSXp2Eb7qTrWZEnn5u5Hzs1nItcpdfx4s6S356THkrqWuFXSUZK6K2eGktbIZ4W3SbpR0hY1XtIrgfXy9u9SGgfjxrzNJZJWz/uaLulHkmbw8gJhHVLXLwBExG158qPA9RFxZV7+LPAZ4PO13tsqxwFfqbG83rGWIemgnIdZks7Ny8bms6XblMbOeG0vn4lG73fDz1pOt6HSmCKzJR1TJ85jJX26MD9Z0uckrSPp2vy+3C7pXY1erBxT8XPXk5+783t3saS7JZ0nSXndW/NndpbSd2mUpJUlnZVjvkXShJz2RqU++yr7n650NjxC0pl5+1skVb7HkyRdKulq4KoG6VaRNFVp/JtLSL1MDy2DdTfnK/UB9ABbkHqLXZl0V203cFkhzTTgXaRecWcXlk8mdez2a9KYKl8BJpL6Phpf41hzWHqn7EGVYwBTgMvIY4CQuo2ojOewLXB1nv4tMCFP7wP8PE+vWTjGMcDhxfh62ecU0h3ey5HuAr8vL98V+Cuwap5fo9F+qvI5GZgJrJLnVwVWztMbAzPydPXrvGQeOAn4ep7eEbi1xnHGArcX5m8DdsjT3wR+lKenA6fUef/fCzxN6jb8KywdI+d44Mga6Z8iddsziRp3Luf3uAu4C3gD6S7oKY2OVbX9m0h3TK9V9br/jqVjZnwM+E0vn4lG73eZz9qlpD7uAD4N9NSI9c3Anwvzd5L6rTqapZ/z5YFRvXwHpwB7F7+Thc/DAlL/V8sBN5A6D12J1J3JW3O60aQuTo4GzszLNiX1+rwycBTwjbx8HeCePP0d4IA8vVp+3Ufk93Zu4bWvl+7/FY63BbCYGt/7wXx09OlVp4qI2ySNJZ2dLFOvLamL9CP4l4gISS9I2jwibi8kq5y5vBd4N3Bwg8NdUHguVtNcFBEvKnUO93bgovxnDKAyTsuFpB+Na/LxTsnLN8//IlcjdQFyRVUeGu0T0o/TS8CdOb8A7yH1TfUsQEQ8WWI/RZdGxHN5ekXgZElbkXpR3aTONkXvJA0rQERcrdSd9+iIqDnGiKQxpEGU/pwXnU0qKCsurLVdRFyhVI25C6kQvUXS5iXia+RF4AfAl0l9fzU8VkT8u7DtjqTPwuN5m0oX+NuxtIvzc4HvF/K1zGeixPtU5rP2DvLrn4/3vepMRsQtktaWtC5pvJGnIuJfkm4CzpS0IumzdWvDV6uxv0fubVfSraQ/EQuARyLiphzHwrz+naQ/IkTE3ZIeIn3Wfkk6m/068BHSn0dI4/DsoaXtjCsDr83T0wqvfb102wMn5uPdJqnmGedgcoEyeC4Ffkj6V1QcU+Ej5E7y8pduNKngKVZpXEb6AZkREQsLX85aos70M/l5OeDpiNiqTozfkbQGqU2nMijPFOADETFL0iSW7S22t30CFMeBaRR8b/speqYwfRQwH9gy7+P/SmzfbM/UW5F/OM4Hzleqctue9G97+2K6XBg8Eakn2N6Ody6pQCn+8ah3rF+9fPPSan0mRtD4fSrzWYNlP5/1XEQ6C3sNudCOiGslbU+qRp4i6fiIOKfBPhbnWMjVdysV1hU/my/Sj9/IiJgn6QmlatN9gMPyKpF69r2nmF7Stiz7eamXrq+htJ3bUAbPmaTT4tlVy/cDdomIsRExlvSlXaYdJf+L/yKpp9De7FN4vqF6Zf639aCkDwMo2TKv6wFuIg0JelksHdVwFPBI/ke4f1/22cA04GDl9hhJa/RzP5BGNnwknwUdSKoGAViUY6/lukpeJHUDj9c7OwGIiAXAU4X6+gOBP9dLXyFpx0IeRwEbkapKzgPeKek9ed0qpH+jX+9tnzmeF0hnoEuuPmtwrKKrgQ8rDxSVCwpI1Y+Vz93+pNen5mei7PvUS7rrq45Xz4U53d7kM0JJrwPmR8TPSJ0dvqXB9pCqCbfO03uQzmgbuQdYR9Jb8/FGKTWeFz8zm5DOIiqFwIXAF4AxsbTt6grgcGlJu8yb6xyvXrpryReV5LPaWu18g8oFyiCJiLkRscwlq7ka7HXAjYV0DwIL8r+Y4vZTI+LmEodaPZ8aH0nhx6bK/sAhkmaRrhjbs7DuQlJvqsUqnK8CfyP9CNzdj32+TET8kfTvd0auaqic7vdpP9kpwMS8zaYs/fd3G/CiUsNq9WsxmXS11G2kxvuJJY4zEfhB3mYrUjtKb7Ym5fE2UgH/84i4KVfX7QF8RdI/SBdaXB8R5xW2nSRpbuGxftW+z2DZf9Q1j1XcICLuIP0x+XN+vY7Pqw4nFfC3kQrL4sUFtT4TZd+neumOBD4taTYNRmzM8Y4C5kXEI3lxNzBLacCofUiFHZJ+rtqX1f6MNMDULFLVXt2zyXzM/+T9npS3mUaqhjoFWC7HfCFpmIHKGc7FpILvl4VdfYtUeN0m6Y48X0u9dKcCIyXdRfqszWwU92Bwb8PDmKQ5pEa7mleB2dAl6QOkH/cJEfHQIIdjVooLlGHMBYqZtZMLFDMzawq3oZiZWVO4QDEzs6ZwgWJmZk3hAsXMzJrCBYqZmTXF/wf0h4APB38urQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "wasting_prevalence_ratio.query(\"wasting_state == 'moderate_acute_malnutrition'\").value.hist(bins=20, density=True)\n",
+    "plt.xlabel(\"MAM prevalence ratio for SQLNS covered vs. uncovered\")\n",
+    "plt.ylabel(\"Probability density over 288 combinations\\nof (year, sex, age, draw)\")\n",
+    "plt.title(\"MAM Prevalence Ratio Histogram\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d134ae10",
+   "metadata": {},
+   "source": [
+    "# 5. Validation: Check to see how much of SAM prevalence decreases from reduction in MAM incidence from MILD\n",
+    "\n",
+    "Since the prevalence of MAM has increased, there will be fewer people transitioning from MAM into SAM, so the prevalence of SAM should decrase as well. But how much?\n",
+    "\n",
+    "The prevalence of SAM decreases by a factor of 0.89 (95% UI 0.81 to 1.0)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "c22b6965",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "count    288.000000\n",
+       "mean       0.893418\n",
+       "std        0.047123\n",
+       "min        0.791420\n",
+       "2.5%       0.815943\n",
+       "50%        0.888211\n",
+       "97.5%      0.998365\n",
+       "max        1.038445\n",
+       "Name: value, dtype: float64"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wasting_prevalence_ratio.query(\n",
+    "    \"wasting_state == 'severe_acute_malnutrition'\").value.describe(percentiles=[.025, .975])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "072fa35e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZQAAAEWCAYAAABBvWFzAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAxKElEQVR4nO3deZhcRb3/8feHsEoCBIK57EFkEQ2LREFQCCggYkQRQWRf5IJs8sMFrl7FHRVQQFFR9i0sgiJehAgMKgKaBJKwJIAQZCcgSyYCkvD9/VHV5GTS3XNmpnume+bzep5+5vRZv3VOT1efqjpVigjMzMz6aomBDsDMzAYHZyhmZtYQzlDMzKwhnKGYmVlDOEMxM7OGcIZiZmYN4QzFBj1JYySFpCUHOpZmkXS9pAOatO8PSJrVjH3b4OIMZYiQ9H5Jf5X0kqR/SbpN0nu6rDNcUqek66tsP1vSfySN6jL/rvxlPabGcTskvZr3+5ykqyWt1tDEtaF8zubl8/KEpNMkDSu57UmSLi7Oi4hdIuKCXsQxXtLjVeZ3SDo07/vPEbFhb+KyocUZyhAgaQXgOuBMYGVgDeAbwGtdVv1knrejpP+qsqtHgL0L+x0LvKVECEdFxHBgA2Al4EdVYhy0dw91bJrPy3bAXsDBAxxPyxqin4+24wxlaNgAICIui4gFEfFKRNwYEdO7rHcA8HNgOrBvlf1cBOzfZf0LywYREf8Cfg28C9686/mypOnAPElLStoq30m9KGmapPF53b0kTS7uT9Jxkq7N07vmu6WXJT0m6aRacUhaUdI5kp7KdwffrtwdSDpQ0l8knSLpBUmPSNqlsO3Kks6T9GRe/pvCso9KujvH/ldJm5Q8Lw8BtwGbFfZ1ek7Hy5KmSPpAnv9h4H+AvfLdzbQ8/807CklLSPqqpEclPSvpQkkrlomlxvla5C4mX7MnJM2VNEvSB+vEtbqka/Nd8UOSPlvYz3KSLsjn8X5JX+pynGqfjxMk/SMf+z5Jnyisf2C+8/5RvgYPS9o6z38sn4umFAtaFhF+DfIXsALwPHABsAswsso66wBvABsDxwPTuyyfDXwImAW8AxgGPJ63C2BMjWN3AIfm6VHAzcBFhX3eDawFLEe6c3oe+Ajpx86O+f2qpDuhucD6hX3/Hfh0nh4PjM3bbQI8A3w8LxuTY1wyv78G+AWwPPBW4G/Af+dlBwKvA5/NaTwCeBJQXv574HJgJLAUsF2evznwLLBl3u6AnL5lapyXAN6epzcCngKOKyzfF1gFWDJfj6eBZfOyk4CL65zng4GHgLcBw4GrK+e8Shzjgce7uW5vrgNsCDwGrF44t+vVietPwFnAsqQMcw6wQ152MnBrPpdrkn7IPF7YdjaFz0ee9ylg9Xyd9wLmAasVrt184KB8Db4N/BP4KbAMsBPpMzR8oP8nB+trwAPwq58udMoEzidlAvOBa4HRheVfBe7O02sAC4DNC8tnkzKUrwLfAz4MTMpfeN1lKP8GXgSeAC4BVi3s8+DCul/u+sUH3AAckKcvBr6Wp9fPXw5vqXHcHwM/ytNjcoxLAqNJxXrLFdbdG7glTx8IPFRY9pa87X8Bq5Ey3WoZ8s+Ab3WZN4uc4VRZP4CX8xdiAJdRI/PJ679AKiKD7jOUm4DPFZZtSMokl6yy3/E5TS92ec2neobydlLG+SFgqS77WiQuUkawABhRmPc94Pw8/TCwc2HZoSyeoRxc65zkde4GditcuwcLy8bmc1v8nD8PbDbQ/4+D9eUiryEiIu6PiAMjYk1SkdPqpC/div1JX/ZExBOkX47VigcuAj5D+uctW9x1TESsFBFrRMQ+ETGnsOyxwvQ6wKdyccWLkl4E3k/6Ige4lIV1OJ8BfhMR/waQtKWkWyTNkfQScDjpjqirdUh3Fk8VjvEL0p1KxdOVicr+Sb/01wL+FREv1Njv8V1iX4t0nmt5d97vXqQ7m+UrCyR9IRcDvZT3tWKN9FSzOvBo4f2jLMxMq3kyX583X8Bfqq0YqXju86TM41lJEyXVSuPqpPM1t0ssaxSWF69/cbrqPEn7F4oVXyR9lovn5ZnC9Cs55q7zhteI1/rIGcoQFBEzSXcrlbqMrUm/+E+U9LSkp0lfcJ/pWhkaEY+SKuc/QipK6XM4henHSHcoxS+35SPi5Lx8ErCqpM1IGculhW0vJd11rRURK5LqglTleI+R7lBGFY6xQkS8s0SsjwErS1qpxrLvdIn9LRFxWb0dRnIFcDvwNUjNdIEvAXuS7oZWAl4qpKe7LsKfJGVwFWuT7jieqb56z0TEpRHxfhYWd36/RlxPks7XiC6xPJGnnyIVdVWsVe1wlQlJ6wC/BI4CVsnn5R6qX2cbAM5QhgBJG0k6XtKa+f1apC/kO/IqB5C+rDcmlXNvRspsliPVuXR1CKkcfF6DQ70YmCBpZ0nDJC2bK4TXBIiI14ErgR+SWqtNKmw7gvRr+FVJ7yXdwSwmIp4CbgROlbRCrsBeT9J23QWXt70eOEvSSElLSdo2L/4lcHi+U5Kk5ZUaCoyovcdFnAx8Vql13QhSBjAHWFLS10j1YBXPAGMk1fr/vQw4TtK6koYD3wUuj4j5JWOpSdKGknaQtAzwKukX/xvV4oqIx4C/At/L13IT0men0rT4CtKPmJGS1iBlFPUsT8pg5uRYDiL/KLLW4AxlaJhLuuO4U9I8UkZyD6mIZlnSL+EzI+LpwusRUvHWYsVeEfGPiJjcdX5f5S+g3UitheaQfvV/kUU/p5eSyu+v7PIF+Tngm5Lmkn7pX1HnUPsDSwP3keomrmJhsVp39iPVR8wk1SV8Psc+mVSR/5O8z4dIxYKlRMQMUgX2F0n1Rn8AHiAVEb3KokU/V+a/z0uaWmV355Ku3Z9Id5OvAkeXjaUby5Ayv+dIRYNvBU6sE9fepDqsJ0mNIb4eEX/My75JqtN7BPgj6Tp0bcr+poi4DziVdDf3DKmO5LZGJMoao9JyxcxsQEk6gtRqr9u7RWtNvkMxswEhaTVJ2+Rixw1JzaOvGei4rPf89KmZDZSlSS3s1iU1VZ5IembF2lTLFHlJOhf4KPBsRFRaH61MeohsDKlN+p41mmyamdkAa6Uir/NJD8sVnQDcFBHrkx7WOqG/gzIzs3Ja5g4FUjfjwHWFO5RZwPiIeEqph9qO6KbX01GjRsWYMWOaHuu8efNYfvnlu19xkBmK6R6KaQaneyiZN28eM2fOfC4iVu3Lflq9DmV0bvsPqYli1Sd9JR0GHAYwevRoTjnllKYH1tnZyfDhQ++B26GY7qGYZnC6h5LOzk4mTJjwaPdr1tfqGcqbIiIkVb2dioizgbMBxo0bF+PHj296PB0dHfTHcVrNUEz3UEwzON1DSUdHR0P200p1KNU8k4u6yH+fHeB4zMyshlbPUK5l4ZPaBwC/HcBYzMysjpbJUCRdRupSYUNJj0s6hNTFw46SHiR1t3FyvX2YmdnA6bYORdI2pHEy5knal9Tl9um519mGiYi9ayz6YCOPY2ZmzVHmDuVnwL8lbUrqGuEf9GDYVzMzGxrKZCjzIz2sshvwk4j4Kal7bTMzszeVaTY8V9KJpDGut81jHSzV3LDMzKzdlLlD2Ys0RsEhEfE0aYS1HzY1KjMzazvd3qHkTOS0wvt/4joUy8ac8Ptebzv75F0bGImZDbRu71Ak7S7pQUkvSXpZ0lxJL/dHcGZm1j7K1KH8AJgQEfc3OxgzM2tfZepQnnFmYmZm3SlzhzJZ0uXAb0iV8wBExNXNCsrMzNpPmQxlBeDfwE6FeQE4QzEzszeVaeV1UH8EYmZm7a1MK681JV0j6dn8+rWkNfsjODMzax9lKuXPI3Ujv3p+/S7PMzMze1OZDGXViDgvIubn1/lAn8YdNjOzwadMhvK8pH0lDcuvfYHnmx2YmZm1lzIZysHAnsDTwFPAHoAr6s3MbBFlWnk9CnysH2IxM7M2VjNDkfSliPiBpDNJz50sIiKOaWpkZmbWVurdoVS6W5ncH4GYmVl7q5mhRMTv8uS/I+LK4jJJn2pqVGZm1nbKVMqfWHKemZkNYfXqUHYBPgKsIemMwqIVgPnNDszMzNpLvTqUJ0n1Jx8DphTmzwWOa2ZQZmbWfurVoUwDpkm6NCJe78eYzMysDZXpvn6MpO8BGwPLVmZGxNuaFpWZmbWdsp1D/oxUb7I9cCFwcTODMjOz9lMmQ1kuIm4CFBGPRsRJwK7NDcvMzNpNmSKv1yQtATwo6SjgCWB4c8MyM7N2UyZDORZ4C3AM8C1gB+CAZgZlQ8OYE37f621nn+ybZLNWU6ZzyL/nyU7cy7CZmdXQbYYiaQPgi8A6xfUjYocmxmVmZm2mTJHXlcDPgV8CC5objpmZtasyGcr8iPhZ0yMxM7O2VqbZ8O8kfU7SapJWrryaHpmZmbWVMncolRZdXyzMC6DfnpSXdBxwaD7uDOCgiHi1v45vracvLcR66vix8zmwcDy3MDOrrkwrr3X7I5BaJK1BarK8cUS8IukK4NPA+QMZl5mZLape9/U7RMTNknavtjwirm5eWItZElhO0uukZ2Ke7Mdjm5lZCYpYbLj4tED6RkR8XdJ5VRZHRBzc3NAWieVY4DvAK8CNEbFPl+WHAYcBjB49eouJEyc2PabOzk6GDx96HQZ0TfeMJ14awGj6x+jl4JlXFr4fu8aKAxdMP/JnfOjo7OxkwoQJUyJiXF/2UzNDaRWSRgK/BvYCXiQ1Y74qIqp2UDlu3LiYPHly0+Pq6Ohg/PjxTT9Oq+ma7v6syxgox4+dz6kzFt7MD5U6FH/Gh46Ojg623377Pmco3bbykrSKpDMkTZU0RdLpklbpy0F76EPAIxExJ4/LcjWwdT8e38zMSijTbHgiMAf4JLBHnr68mUF18U9gK0lvkSTgg8D9/Xh8MzMroUyGslpEfCsiHsmvbwOjmx1YRUTcCVwFTCU1GV4COLu/jm9mZuWUyVBulPRpSUvk157ADc0OrCgivh4RG0XEuyJiv4h4rT+Pb2Zm3avXbHgu6UFCAZ9n4SiNS5B6Hv5CnW1HAquTWmXNjog3GhSvmZm1qJoZSkSM6MmOJK0IHAnsDSxNqmtZFhgt6Q7grIi4pQ+xmplZCyvT9QqSNgHGsGj39V0fbLyKNN78ByLixS7bbwHsJ+ltEXFOXwI2M7PWVGY8lHOBTYB7gUrRVZCa774pInastY+ImAJM6X2YZmbW6srcoWwVERuX3aGki4FbgT9HxMxeR2ZmZm2lTCuv2yWVzlCAc4DVgDMlPSzp17nrFDMzG8TK3KFcSMpUngZeI7X6iojYpNrKEXGLpD8B7wG2Bw4H3gmc3piQzcysFZXJUM4B9iM9VNht819JNwHLA7cDfwbeExHP9iVIMzNrfWUylDkRcW0P9jkd2AJ4F/AS8KKk2yPilfqbmZlZOyuTodwl6VLgd6QiL6D2eCgRcRyApBHAgcB5wH8By/Q1WDMza11lMpTlSBnJToV5izUbrpB0FPAB0l3KbOBcUtGXmZkNYmWGAD6oh/tcFjgNmBIR83sVlZmZtZ0y46GsKekaSc/m168lrVlr/Yg4JfcQvLKktSuvhkZtZmYtp8xzKOcB15I6e1ydVJdSbVhgACRNkPQg8AjpAcfZwPV9jtTMzFpamQxl1Yg4LyLm59f5wKp11v82sBXwQESsSxoQ646+h2pmZq2sTIbyvKR9JQ3Lr32B5+us/3pEPA8sIWmJ3MNwn8YpNjOz1lemldfBwJnAj0itu/4K1Kuof1HScOBPwCWSngXm9TVQMzNrbWVaeT0KfKwH+9yNNLDWccA+wIrAN3sVnZmZtY0yrbwukLRS4f3I3KV9tXWHAddFxBu5vuWCiDgjF4GZmdkgVqYOZZPigFkR8QKwebUVI2IB8EYevdHMzIaQMnUoS0gamTMSJK3czXadwAxJkyjUnUTEMX2K1MzMWlqZDOVUUvf1V+b3nwK+U2f9q6nRLYuZmQ1eZSrlL5Q0Gdghz9o9Iu6rs/4FjQrOzMzaR5k7FHIGUjMTAZA0g9SsuNY+qg7IZWZmg0OpDKWkj+a/R+a/F+W/+1InozEzs8GhYRlKfl4FSTtGRLEV2JclTQVOaNSxzMys9dRtNixpycL0cEnjciuvbjbTNoU3W3d3HDMza381v+glHQg8I+kBSbuQhvb9PjBN0t519nkIcJak2ZJmA2eRum8xM7NBrF6R1/HAhsAIYBqweUT8Q9JoYBJwWbWNImIKsGnl4caIeKmxIZuZWSuql6EsiIjngOckdUbEPwAi4hlJ3e7YGYmZ2dBSL0P5p6Tvke5QZko6lfTA4oeAp/ojODMzax/1Ksv3BV4GHif1Nnw7cCIwGjiw6ZGZmVlbqXmHEhEvA98rzLoqv3pE0jjgyYh4sufhmZlZu6jXymucpFskXSxpLUmTJL0o6e+SqvY2XMPRwO8lXd73cM3MrFXVq0M5C/g6sBJplMbjImJHSR/My95X5gARcQCApBF9C9XMzFpZvTqUpSLi+oi4DIiIuIo0cROwbK2NlOwr6Wv5/dqS3hsRc3sbpKSVJF0laaak+yWVyszMzKz/1MtQXpW0k6RPASHp4wCStgMW1NmucvdSefhxLvDTPsZ5OvCHiNgI2BS4v4/7MzOzBqtX5HU48APgDWBn4AhJ5wNPAIfV2W7LiHi3pLsgjfAoaeneBpgfkNyW3LIsIv4D/Ke3+zMzs+ZQRGM7ApZ0J7A18PecsawK3Nilw8ie7G8z4GxS9/mbAlOAYyNiXmGdw8iZ3OjRo7eYOHFi3xJRQmdnJ8OHD2/6cVpN13TPeGLwP786ejl45pWF78euMTRGuPZnfOjo7OxkwoQJUyJiXF/2U7e3YUkbAWsAd0ZEZ2H+hyPiDzU2OwO4BnirpO8AewBf7WOM7waOjog7JZ1O6rn4fysrRMTZpEyHcePGxfjx4/twuHI6Ojroj+O0mq7pPvCE3w9cMP3k+LHzOXXGwn+V2fuMH7hg+pE/40NHR0dHQ/ZTM0ORdAxpbJP7gXMkHRsRv82LvwtUzVAi4hJJU4APAgI+HhF9qfN4HHg8Iu7M76/CXeHbABozQJno7JN3HZDjmpVV7w7ls8AWEdEpaQxwlaQxEXE6KaOoKndv/yyFziMlLRURr/cmwIh4WtJjkjaMiFmkjKru6JFmZtb/6mUoS1SKuSJitqTxpExlHepkKMBUYC3ghbzeSsDTkp4BPpt7I+6po4FLcuX+w8BBvdiHmZk1Ub1mw8/kCnEAcubyUWAUMLbOdpOAj0TEqIhYBdgFuA74HKlJcY9FxN0RMS4iNomIj0fEC73Zj5mZNU+9DGV/4OnijIiYHxH7k5rx1rJVRNxQ2OZG4H0RcQewTF+CNTOz1lWvc8jH6yy7rc4+n5L0ZaDSdncv0t3OMNIzLWZmNgjVbTbcS58h9QH2m/z+tjxvGLBnE45nfdSTVkvHj50/JJoKm1nPNTxDyaM8Hl1j8UONPp6ZmbWG7h5sHAb8MSK2L7vD/GT8l4B3UuhEMiJ26G2QZmbW+upVyhMRC4A3cn9aZV0CzATWBb4BzAb+3tsAzcysPZQp8uoEZkiaBLzZf1ZEHFNj/VUiovJk/a3ArZKcoZiZDXJlMpSr86usyhPxT0naFXgSWLmngZmZWXvpNkOJiAskLQesnbs+6c63cxHZ8cCZwArAcX0L0+oZqL6lzMyKus1QJE0ATgGWBtbNT89/MyI+Vm39iLguT74ElK7MNzOz9la3Uj47CXgv8CKkblCAtzUtIjMza0tlMpTXI6LrKEp+4t3MzBZRplL+XkmfAYZJWh84Bvhrc8MyM7N2U+YO5WjSQ4qvAZeS6kY+X/YAknaTtGWvojMzs7ZR5g5lo4j4CvCVXh5jS2CspCUjYpde7sPMzFpcmQzlVEn/RRp69/KIuKcnB4iI/+lVZGZm1la6LfLK/XhtD8wBfiFphqSv1lpf0rckLVl4v4Kk8xoSrZmZtawydShExNMRcQZwOHA38LU6qy8J3ClpE0k7kvrx6s2wv2Zm1kbKPNj4DtIgWXsAzwGXk56CryoiTpT0R+BO0rjy20aEu603MxvkytShnEsafXGniHiyu5UlbQucAXyTNPb8mZIOKbOtmZm1rzJ9eb1P0tLABpJWBmZFxOt1NjkF+FRE3AcgaXfgZmCjRgRsNlT1pc+22Sfv2sBIzKorU+S1HXAhaVwTAWtJOiAi/lRjk/flcVQAiIirJd3aiGDNzKx1lamUP41U3LVdRGwL7Az8qM7660m6SdI9AJI2AY7oe6hmZtbKymQoSxW7rY+IB4Cl6qz/S+BE8rgoETEd+HRfgjQzs9ZXplJ+sqRfARfn9/sAk+us/5aI+Juk4rz5vYzPzMzaRJkM5QjgSFKnkAB/Bs6qs/5zktYDAkDSHsBTfQnSzMxaX5lWXq+R6lFOK7nPI4GzgY0kPQE8Auzb6wjNrM9600Ls+LHzOfCE37uFmJVW5g6lRyLiYeBDkpYHloiIuY0+hpmZtZ5SXa/0hKRjJa0A/Bv4kaSpknZq9HHMzKy1dJuhSBrbw30eHBEvAzsBqwD7ASf3IjYzM2sjZe5QzpL0N0mfk7RiifUrzbs+AlwYEfcW5pmZ2SBVpvv6D5CaCq8FTJF0ae5FuJYpkm4kZSg3SBqBx6A3Mxv0SlXKR8SDeQyUyaSOHzdXetDkfyLi6i6rHwJsBjwcEf+WtApwUANjNjOzFlSmL69NSBnCrsAkYEJETJW0OnA7sEiGEhFvAFML758Hnm9k0GZm1nrK1KGcScogNo2IIyNiKkDujr7myI2NJmmYpLskXddfxzQzs/LKZCjXRMRFEfFKZYakYwEi4qKmRba4Y4H7+/F4ZmbWA2UylP2rzDuwwXHUJWlNUpHbr/rzuGZmVp4iovoCaW/gM8D7Sf13VYwA3oiID5Y6gFS5q/hpRPykV0FKVwHfy8f+QkR8tMvyw4DDAEaPHr3FxIkTe3OYHuns7GT48OFNP04ZM554qd+ONXo5eOaV7tcbTIZimmFhuseuUeZpgcGjlf63+0tnZycTJkyYEhHj+rKfepXyfyV16jgKOLUwfy4wvewBIuIduaXXVr0JUNJHgWcjYoqk8TWOcTap/zDGjRsX48dXXa2hOjo66I/jlHFgH0by66njx87n1BkN77GnpQ3FNMPCdM/eZ/xAh9KvWul/u790dHQ0ZD81/0si4lHgUeB9ZXcmaRjwx4jYvsu+ngd6+623DfAxSR8BlgVWkHRxRLjDSTOzFlKzDkXSX/LfuZJeLrzmSnq52jZ56N83Sj5RX0pEnBgRa0bEGNJAXTc7MzEzaz317lDen/+O6OE+O4EZkiYB8wr7O6b2JmZm1u7KPNi4HvB4RLyW6zA2IfXR9WKNTa6my8OOjRIRHUBHM/ZtZmZ9U6am8dfAOElvJ1V8/xa4lNRX12Ii4oLGhWdmZu2iTIbyRkTMl/QJ4MyIOFPSXbVWlrQ+qYnvxqRKdAAi4m19jtbMzFpWmQcbX8/PpBwAVLo9WarO+ucBPwPmA9sDFwIX9yVIMzNrfWUylINITYe/ExGPSFoXqNflynIRcRPpoclHI+Ik0lPuZmY2iHVb5BUR9wHHFN4/Any/ziavSVoCeFDSUcATwNB67NTMbAgqMwTwNpImSXpA0sOSHpH0cJ1NjgXeQsqEtgD2JRWXmZnZIFamUv4c4DhgCrCgu5Uj4u8Akt6ICA+sZWY2RJSpQ3kpIq6PiGcj4vnKq9bKkt4n6T5gZn6/qaSzGhWwmZm1pjJ3KLdI+iHpYcXXKjMrA21V8WNgZ+DavN40Sdv2MU4zGyBj+tj56OyT3SZnqCiToWyZ/xa7NQ5gh1obRMRjacj5N3VbVGZmZu2tTCuv7btbp4vHJG0NhKSl8EiLZmZDQplWXqMlnSPp+vx+Y0mH1NnkcOBIYA1Sk+HN8nszMxvEylTKnw/cAKye3z8AfL7O+hER+0TE6Ih4a0TsW68S38zMBocyGcqoiLgCeAMgIuZTv07kDklXStpFXSpSzMxs8CqToczLQ/gGgKStgHqDmG9A6pV4f9LT8t+VtEGfIzUzs5ZWppXX/yM1AV5P0m3AqsAetVaOiAAmAZMkbU/qGPJzkqYBJ0TE7X0P28zMWk2ZVl5TJW0HbAgImBURr9daP9/N7AvsBzwDHE3KkDYDrgTW7XvYZmbWampmKJJ2r7FoA0lERK1RGW8n9Ub88Yh4vDB/sqSf9zJOMzNrcfXuUCbkv28FtgZuzu+3B/5K7WF+N8zFXouJiHq9FJuZWRurmaFUOnaUdCOwcUQ8ld+vRmpKvAhJvwTOiIgZVZYtD+wFvBYRlzQmdDMzayVlKuXXqmQm2TPA2lXW+ynwv5LGAvcAc0hDAK8PrACcCzgzqaGv/SWZmQ20MhnKTZJuAC7L7/cC/th1pYi4G9hT0nBSv1+rAa8A90fErMaEa2ZmrapMK6+jJH0CqPQYfHZEXFNn/U6gozHhmZlZuyhzh0LOQGpmImZmZmWelDczM+tWwzIUSRflv8c2ap9mZtY+ynRfP0FSmYxnC0mrAwdLGilp5eKr76GamVkrK1OHshfwY0m/Bs6NiJk11vs5cBPwNmAKqZuWisjzzcxskOr2ziMi9gU2B/4BnC/pdkmHSRrRZb0zIuIdpEznbRGxbuHlzMTMbJArVYcSES8DVwETSc+XfAKYKunoKuseIWlTSUfl1yYNjdjMzFpSmTqU3SRdQ3q2ZCngvRGxC7ApcHyV9Y8hPRH/1vy6pFrGY2Zmg0uZOpTdgR9FxJ+KMyPi3zXGlj8U2DIi5gFI+j6pB+Iz+xqsmZm1rjJFXk93zUxyJkFE3FRlfbHoEMELWLSC3szMBqEyGcqOVebtUmf984A7JZ0k6STgDuCcXsRmZmZtpN4AW0cAnyMN/Tu9sGgEcFut7SLiNEkdwPvzrIMi4q7eBihpLeBCYDSp+fHZEXF6b/dnZmbNUa8O5VLgeuB7wAmF+XMj4l/1dhoRU4GpfQ8PgPnA8Xko4hHAFEmTIuK+Bu3fzMwaoF6RV0TEbOBIYG7hRX8++R4RT+UMioiYC9wPrNFfxzczs3JUY7ReJF0XER+V9AipqGmRJ98H4mFFSWOAPwHvys/GVOYfBhwGMHr06C0mTpzY9Fg6OzsZPnx4w/Y344mXGravZhq9HDzzykBH0b+GYpqhcekeu8aKfd9JP2r0/3Y76OzsZMKECVMiYlxf9lMzQ2k1eeCuW4HvRESt8ewZN25cTJ48uenxdHR0MH78+Ibtr11GbDx+7HxOnVFq1INBYyimGVoj3bNP3rXfj9no/+120NHRwfbbb9/nDKVepfy7621YKYbqD5KWAn4NXFIvMzEzs4FT7+fHqXWWBbBDg2OpSpJIzY7vj4jT+uOYZmbWczUzlIjYvj8DqWMbYD9ghqS787z/iYj/G7iQzMysq3pFXjtExM2Sdq+2vL+KniLiL/hJezOzllevyGs74GZgQpVlAbguw8zM3lSvyOvr+e9B/ReOmZm1qzLd168i6QxJUyVNkXS6pFX6IzgzM2sfZTqHnAjMAT4J7JGnL29mUGZm1n7KPLW0WkR8q/D+25L2alZAZmbWnsrcodwo6dOSlsivPYEbmh2YmZm1l3rNhueysA+vzwMX50VLAJ3AF5odnJmZtY96rbxG9GcgZmbW3kr1/CZpJLA+sGxlXtdhgc3MbGjrNkORdChwLLAmcDewFXA7/dSXl5mZtYcylfLHAu8BHs39e20OvNjMoMzMrP2UyVBejYhXASQtExEzgQ2bG5aZmbWbMnUoj0taCfgNMEnSC8CjzQzKzMzaT7cZSkR8Ik+eJOkWYEXgD02NagCVHTnx+LHzObBNRlk0a1cDMZJpI/63B2KkyVZQtpXXu4H3k55LuS0i/tPUqMzMrO2U6Rzya8AFwCrAKOA8SV9tdmBmZtZeytyh7ANsWqiYP5nUfPjbTYzLzMzaTJlWXk9SeKARWAZ4ojnhmJlZu6rXl9eZpDqTl4B7JU3K73cE/tY/4ZmZWbuoV+Q1Of+dAlxTmN/RtGjMzKxt1esc8oLKtKSlgQ3y21kR8XqzAzMzs/ZSpi+v8aRWXrNJXdmvJekAdw5pZmZFZVp5nQrsFBGzACRtAFwGbNHMwMzMrL2UaeW1VCUzAYiIB4ClmheSmZm1ozJ3KFMk/YqFIzbuw8IKezMzM6BchnI4cCRwTH7/Z+CspkVkZmZtqW6GImkYMC0iNgJO65+QzMyGrr50iDnQnVLWrUOJiAXALElr91M8ZmbWpsoUeY0kPSn/N2BeZWZEfKxpUZmZWdspk6H8b9OjMDOztlevL69lSRXybwdmAOdExPz+CszMzNpLvTqUC4BxpMxkF9IDjmZmZlXVK/LaOCLGAkg6B/cwbGZWykAMXdwK6t2hvNkBpIu6zMysO/XuUDaV9HKeFrBcfi8gImKFpkdnZmZto+YdSkQMi4gV8mtERCxZmO7XzETShyXNkvSQpBP689hmZlZOmc4hB1R+Wv+npIYBGwN7S9p4YKMyM7OuWj5DAd4LPBQRD0fEf4CJwG4DHJOZmXWhiBjoGOqStAfw4Yg4NL/fD9gyIo4qrHMYcFh+uyEwa7EdNd4o4Ll+OE6rGYrpHoppBqd7KBkFLB8Rq/ZlJ2WelG95EXE2cHZ/HlPS5IgY15/HbAVDMd1DMc3gdA90HP0pp3lMX/fTDkVeTwBrFd6vmeeZmVkLaYcM5e/A+pLWlbQ08Gng2gGOyczMumj5Iq+ImC/pKOAGYBhwbkTcO8BhQT8XsbWQoZjuoZhmcLqHkoakueUr5c3MrD20Q5GXmZm1AWcoZmbWEM5QquiuqxdJa0u6RdJdkqZL+khh2Yl5u1mSdu7fyHuvt2mWNEbSK5Luzq+f93/0vVci3etIuimnuUPSmoVlB0h6ML8O6N/I+6aP6V5QuN5t00BG0rmSnpV0T43lknRGPifTJb27sKwtr3Uf09zz6xwRfhVepIr/fwBvA5YGppG68i+uczZwRJ7eGJhdmJ4GLAOsm/czbKDT1OQ0jwHuGeg0NDHdVwIH5OkdgIvy9MrAw/nvyDw9cqDT1Ox05/edA52GXqZ7W+DdtT6vwEeA60kd4G4F3DkIrnWv0tzb6+w7lMWV6eolgEoHmSsCT+bp3YCJEfFaRDwCPJT31+r6kuZ2VibdGwM35+lbCst3BiZFxL8i4gVgEvDhfoi5EfqS7rYVEX8C/lVnld2ACyO5A1hJ0mq08bXuQ5p7xRnK4tYAHiu8fzzPKzoJ2FfS48D/AUf3YNtW1Jc0A6ybi8JulfSBpkbaWGXSPQ3YPU9/AhghaZWS27aqvqQbYFlJkyXdIenjTY20f9U6L+18rbtTL209vs7OUHpnb+D8iFiTdMt4kaTBfi5rpfkpYO2I2Bz4f8ClkgbTWDlfALaTdBewHamXhgUDG1K/qJfudSJ1TfIZ4MeS1hugGK25enydB/uXYG+U6erlEOAKgIi4HViW1Llau3YT0+s05+K95/P8KaSy+Q2aHnFjdJvuiHgyInbPGeZX8rwXy2zbwvqSbiLiifz3YaAD2Lz5IfeLWuelna91d2qmrTfX2RnK4sp09fJP4IMAkt5B+nKdk9f7tKRlJK0LrA/8rd8i771ep1nSqkpj1iDpbaQ0P9xvkfdNt+mWNKpw93kicG6evgHYSdJISSOBnfK8dtDrdOf0LlNZB9gGuK/fIm+ua4H9c8unrYCXIuIp2vtad6dqmnt9nQe6FUIrvkhFOg+Qfm1/Jc/7JvCxPL0xcBupnPluYKfCtl/J280CdhnotDQ7zcAngXvzvKnAhIFOS4PTvQfwYF7nV8AyhW0PJjW8eAg4aKDT0h/pBrYGZuTPwQzgkIFOSw/SfBmpiPZ1Ul3BIcDhwOF5uUiD+f0jp21cu1/r3qa5t9fZXa+YmVlDuMjLzMwawhmKmZk1hDMUMzNrCGcoZmbWEM5QzMysIZyhNJCkr0i6N/faebekLQvLlpQ0R9LJXbbpkPRPSSrM+42kzv6MvZYc37iBjqMWSeMlbV14f7ik/Xuw/aqS7sxdx/Sq2xhJW+V93C3pfkknFZZ9PH8eZkq6R9IehWXnF9/neWMkhaSjC/N+IunA7o7VyvJ1um6g42h1rfJ/31stPwRwu5D0PuCjwLsj4rX8MNDShVV2JLXp/5SkE2PR9tovkh4c+ouklYBed86WYxkWEYOmexBJS0bE/BqLxwOdwF8BIqKn3ed/EJgREYf2IJ6u5/cCYM+ImJYf8twwr7cpcAqwY0Q8kh92/aOkRyL1KlDLs8Cxkn4RqfPGoqrHGiiD7bPWDN18fgcV36E0zmrAcxHxGkBEPBcRxR559wZOJz1x/r4u204kPa0MqUO+q6sdIP96nSnpkvzr9CpJb8nLZkv6vqSppExrJ0m3S5oq6UpJw5XGwLiysL83fzVK+plSR3D3SvpGjeMvts/Csb+R58+QtFGeP1zSeXnedEmfrLefLsfqkPRjSZNJX64TCncSf5Q0WtIY0kNax+Vf7B+QdJKkL+R9bKbUsd10SdcoPeVcPMZmwA+A3fL2y0naO8d7j6TvF9btlHSqpGlVrt9bSQ+PERELIqLyRPEXgO9G6nma/Pe7wPHVzm/BHOAmoNq4G7WOVUzXMEmn5DRMr9ztSPpgPn8zlMbJWKabz0S96133s5bX+3D+vE5lYUeTXWO9Q9I7C+87JI2TtJ0WjsVxl6QR9U5YjmlUnh4nqSNPn5TT2iHpYUnHFLbZP5+faZIuyvPGSLo5z79JaRygFSU9qtxzgKTlJT0maSlJ60n6g6Qpkv5c+OyfL+nnku4EflBnvXXzuZsh6dv10tgWBvpJzsHyAoaTnhZ/ADgL2K6wbFlSd+/LAYcBZxaWdQBbAtNJ41TcSBpjZLGxCPL8ALbJ788FvpCnZwNfytOjgD8By+f3Xwa+Rroj/Wdh/s+AffP0yvnvsBzTJoX4xtXaZ+HYR+fpzwG/ytPfB35ciH9kvf10SWsHcFaXbSsP4h4KnJqnT6qcg67v8zndLk9/sxhLYf0DgZ/k6dXz+Vk1n6ubgY/nZUG6M6h27b8GvABcA/w3sGyePxXYtMu6mwJ35+nzgT2qXON7SGOVzMrX4yfAgfWO1WUfRwBXAUtWri3pM/gYsEGedyHw+VqfiRLXu7vPWuV465Oexr4CuK5KrMcB38jTqwGz8vTvWPg5H15JS53/v9mkvuUgfV47Cp+Hv5LGKBoFPA8sBbyT9L9a2WblwnEPyNMHA7/J078Fts/Te7HwM34TsH6e3hK4uXBtryOPh1RnvWuB/fP0kbTpWDOVl+9QGiQiOoEtSBnGHOBy5XJvUlHYLRHxCvBr4OPK/V9lC4C/kO5SlouI2XUO9VhE3JanLwbeX1h2ef67FbmrFEl3k37prhPptvsPwARJSwK7kv5RAPbMvyTvIv2zbdzluFX3WVheuauaQvpSBPgQqVsHACKNJdHdfoouL0yvCdwgaQbwxRxjTZJWBFaKiFvzrAtIgw3V8x7SF9GcfK4uKWyzgHTtFhMR3yR9id1I6pn1D90cp1uROuS7M++vp8f6EPCLnAYi4l+korFHIuKBvM4FwLZ1PhPdXae6nzVgo3y8ByN9W15cI6lXkLp5AdiTlBFC6ubntHxHsVL0rcjo95E6MX2OVJw4mjRo2JV5XuUcQbr7vDRPX8TC/6/LSRkJpP/Ty/Od2NbAlTntv2DR4uorI2JBN+ttQ+oepXK8tuY6lAaKVJbcAXTkL74DSL9U9gbeL2l2XnUV0gd6UmHziaRfnSd1d5g67+flvyINCLR3le0nAkeRBt2ZHBFzlcr2vwC8JyJekHQ+6RdmUb19AryW/y6g/uequ/0UzStMnwmcFhHXShpP9+ep0V6NOnUFEfEP4GeSfknqNHMVUmd6W5D6Q6rYAphc8pjfJX3B3lqcWe1YkXt87qVqn4nurlPdz1ouTuxWRDwh6XlJm5C+sA/P80+W9HtSn2O3Sdo5ImbW2dV8Fhbhd/3svlaY7u7zWcu1wHclrUy6hjcDywMvRsRmNbapnKMlullv0PR/5TuUBpG0oaT1C7M2Ax5VGhvkA6QxQ8ZExBjSrW3Xf9Q/A99j4a+VWtZWagAA6RfqX6qscwewjaS359iWl1TpUv5W0pCgnyV9kUAaiXEe8JKk0cAuPdxnLZNIaSVvM7KX+4E0SmSly/Bi3cJcYLHy9Yh4CXhBC1tu7UeXL+Yq/kYaA2RUvoPcu8Q2SNo1fwFDKuJZQGpocQpwolJdD/nv54EfdrfPnIaZpExpQoljFU0C/jvfcZC/BGcBYyrnnUXPR7XPRNnrVGu9mfl4lTE06v2AuBz4ErBiREzP+1kvImZExPdJvSNvVGd7SEVeW+TpT3azLqQM4VM546+cI0jFY5X6zH1I/5eVEoi/k+pBr4tUf/Uy8IikT+V9SKkhxiK6We+2Lsdra85QGmc4cIGk+yRNJxUDnEQa7e7myJX12W9JRQzLVGZEckrlFryOWcCRku4n1Sv8rOsKETGHVDdwWY7ldvI/ZP6VfR0p07guz5tGKuqaSbrdv60n+6zj28BIpcrhaaQy6N7sB9K5vFLSFKB4jn4HfEK5Ur7LNgcAP8zH2YxUj1JTpK7KTyANeTsNmBIRv623TbYfMCsXZ1wE7JO/cO4m1Sn8TtIDpDL7IyJiVmHbX0h6PL9ur7Lv75CK++oeq8s2vyLVi0zP5/0zEfEqcBDpHM4A3gB+ntNd7TNR6jrVWi8f7zDg97ko9dk65+8q0pfqFYV5n8+fm+mknnKvB8jpruYbwOlKjTi6bXUWEfeSzu2t+RydlhcdDRyUj7sfcGxhs8tJ9UvFoth9gEPyPu6l9lDJtdY7lvT/PINBMAqkextuI/kX7nUR8a6BjsV6TukZpC2BnWPx5sBmbc91KGb9JCJOGOgYzJrJdyhmZtYQrkMxM7OGcIZiZmYN4QzFzMwawhmKmZk1hDMUMzNriP8P8BbAsrGstBQAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "wasting_prevalence_ratio.query(\"wasting_state == 'severe_acute_malnutrition'\").value.hist(bins=20, density=True)\n",
+    "plt.xlabel(\"SAM prevalence ratio for SQLNS covered vs. uncovered\")\n",
+    "plt.ylabel(\"Probability density over 288 combinations\\nof (year, sex, age, draw)\")\n",
+    "plt.title(\"SAM Prevalence Ratio Histogram\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3cca2f3",
+   "metadata": {},
+   "source": [
+    "# 6. Just for kicks, let's look at the prevalence ratios for the other two wasting categories\n",
+    "\n",
+    "It looks like mild wasting prevalence increases slightly, and TMREL prevalence stays about the same."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "a91d24e0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "count    288.000000\n",
+       "mean       1.043593\n",
+       "std        0.016005\n",
+       "min        1.007703\n",
+       "2.5%       1.014366\n",
+       "50%        1.042474\n",
+       "97.5%      1.079255\n",
+       "max        1.088407\n",
+       "Name: value, dtype: float64"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wasting_prevalence_ratio.query(\n",
+    "    \"wasting_state == 'mild_child_wasting'\").value.describe(percentiles=[.025, .975])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "15bb1007",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYwAAAEWCAYAAAB1xKBvAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAA2HklEQVR4nO3dd7wcVd3H8c+XEIqEDkZ6QEFEQzGRIiIJioCICCKItCA+PCJdLOhjQQUFFFCaiNJbkKZUMQIBRECTQAhVBII0QxFCLk0C3+ePc5YM17uzc+/dvbvJ/b1fr33dKWdmfjM7d8/MOTPnyDYhhBBCI/O1O4AQQghzh8gwQgghVBIZRgghhEoiwwghhFBJZBghhBAqiQwjhBBCJZFhzMUknSLpu3l4jKTHS9KeKenwgYuunKR7JI1pdxytJMmS3tPuOJqpeM71crkR+XjMX2f+tyX9pv8Rhlbq8csL7SVpOrA8sLztZwvT7wDWBVa1Pd32l9sTYe9IOhN43PZ3atNsv799EYUqJI0DvmT7I7VprTrnbP+4YkwTgXNtR+bSBnGH0bkeAXaujUgaCbyjfeHMe5QMyv+Belf687K+fN+D8TiVGZT/LHOJc4DdC+N7AGcXE5QVM0laT9IUSbMkXQgsVG9Dkh6VNCoP75KLDt6fx/eS9Ls8vL6kWyW9IOkpSSdKWiDPk6TjJD0t6UVJ0yR9QNLewC7ANyR1Sboip58u6eN5+DBJv5V0do73HkmjC/F9UNIded5Fki4s2e9xkm7Jsc2UdL+kjxXmT5R0hKRbgJeB1SStKWmCpH9LekDSjjntBpL+JWlIYfntJN3V6Hj0ENeCkn4m6Z+SZuSinYXzvDGSHpd0SD5+T0nas7DswpKOyd/TTEl/Liy7oaS/5BimlhXz5WP+zRz/S5Lml3SopIfysb1X0nY57fuAU4CN8vf2Qp7+tnNO0v9I+kc+dpdLWr7e9rNd8jF4VtL/FdZzmKRz8/BCks6V9Fzer79JGi7pCGAT4MQc04k5/Ydzmpn574cbfN+fyN/zTEknS7pR0pdy+tr5c5yk54DD8j6fLOmavN1bJL1L0s8lPZ/PsfUa7Pe8wXZ8OuwDTAc+DjwAvA8YAjwOrAIYGJHTnQkcnofHkIp9ABYAHgUOBoYCOwCv19L2sL2zgUPy8KnAQ8A+hXkH5+FRwIakoswRwH3AQXneFsBkYAlAOe7lusfZfR/z8GHAq8An877+BLit274cmPdle+A/JfsyDphd2PedgJnAUnn+ROCfwPvzfiwOPAbsmcfXA54F1srpHwI2L6z/IuDQRscjzzfwnjx8HHA5sBSwKHAF8JPCdzcb+GGO+ZOkH7cl8/yTctwr5OPzYWDBPP5cTj8fsHkeX7bkvLoTWAlYOE/7HKn4c758rF4qfG/jgD93W8db3yWwWT5WH8zxnADcVGfbI/Lx+DWwMLAO8BrwvsI5cG4e/t98fN6R93cUsFjh+/tSYb1LAc8Du+XvYec8vnSd73tZ4EXSeTQ/6bx6vbZO5pw/++f5C+d9fjbHsRBwPakEYPcc3+HADe3+3RiIT9xhdLbaXcbmpB+jJyoutyHph+fntl+3fTHwt5L0NwKb5uFNSD/YtfFN83xsT7Z9m+3ZtqcDvyqke530Q7gmINv32X6qYryQfpiutv0Gab/XKezL/MDxeV8uBf7aYF1PM2ffLyRlvFsX5p9p+x7bs4Etgem2z8j7dQdwCemHFOACctGgpEVJP84XVDgeb5EkYG9Sxvtv27OAHwOfLyR7HfhhjvlqoAt4r1IRyheBA20/YfsN23+x/RqwK3B1Pm5v2p4ATMox1nO87cdsv5L34SLbT+blLwQeBNZvcHxrdgFOtz0lx/Mt0h3JiJJlfmD7FdtTganM+Z6LXgeWJmW2b+Tj/GKd9W0NPGj7nPw9XADcD2xTSFP8vrcC7rF9aR4/HvhXt3U+afuEvL5X8rTLchyvApcBr9o+O5+vF5IuNOZ5kWF0tnOAL5Cues4uT/o2ywNPOF8yZY+WpL8R2ETScqQrpt8CG+d//MVJV6VIWkPSlbmY5kXSj94yALavB04kXQ0/LelUSYv1IubiP+3LwEJK5cc97ctjDdbV074Xi0qKy68CbJCLPl7IRS+7AO/K888Htpe0IOmqdIrtR6H8eHSzLOlqeXJhG3/I02ueyz9gxWMwLK9vIdKdTnerAJ/rFvtHgOV6PCr/ve9I2l3SnYXlP1BnH3qyPIXzynYX6Q5nhZJlun/Pw3pIcw5wLTBe0pOSjpY0tEoM2aPdYiju8/LF8XyedH+6sKfza0Zh+JUexnvaj3lOZBgdLP8wPUK6Yry0F4s+BayQr2xrVi7Zzj9I/7z7k4oUXiT9Y+9NuvJ/Myf9JenqbXXbiwHfJhU/1dZzvO1RwFrAGsDXa7N6EXuVfVmpwTI97fuThfHumc+NtpcofIbZ3gfA9r2kH6CtSJn3+YVlS49HwbOkH5X3F7axuO0qPzLPkorr3t3DvMeAc7rFvojtI0vW99a+S1qFVES0H6kIZwng7sI+NPreniRlWrX1LUK6M6h6J9xzgOku6we21yIVv32KOfV53WN6WwzZyt1iKC7zFLBiIWYVx+tsI2SRYXS+vYDNbL/Ui2VuJZXDHiBpqKTtaVzMcCPph+PGPD6x2zikIqcXgS5JawL71GZI+pBSJfFQUjn4q0Ato5kBrNaL+LvvyxvAfrmSdtsK+/JO5uz750j1KVfXSXslsIak3XL6oXlf3ldIcz6prPujpDqMmrrHoyhnuL8GjpP0TgBJK0jaosF+1JY9HThW0vKShkjaKN/xnAtsI2mLPH0hpQr07j+A9SxC+nF8Jse0J+kOo2YGsKLqVOSTiub2lLRujufHwO25eK7PJI2VNFLpYYMXSUVU9c6lq0nf3xfy+bET6YLlyjqrvwoYKekz+Q52X+bcTYYGIsPocLYfsj2pl8v8h1R8Mg74N6kys9Edyo2kH8Cb6owDfI10lT2L9AN4YWHeYnna86Qr8ueAn+Z5pwFr5WKP3/VxX/YCXiCV219JqjCt53ZgddLV+RHADrafq7P+WcAnSPUJT5LurI4iVeLWXECqm7jehfdiKD8e3X0T+AdwWy6++hPw3pL0RV8DppHqof6d45vP9mPAtqQ7m2dIdxxfp+L/db57OoaUKc8ARgK3FJJcD9wD/EvSsz0s/yfgu6Q6n6dId0Gf756uD94FXEzKLO4jnYvn5Hm/AHbITycdn7/XTwGHkM65bwCf6vY9FWN+llQ/dXROvxap3qfsfAqZ3l7UG0Lnk3Q7cIrtM3qYN45uL5uFUE9+qOBxYBfbN7Q7nk4Xdxih40naND/3Pr+kPYC1SZXGIfRaLsJbIhej1eqdbmtzWHOFeIsxzA3eS3pyaxHgYVIRU28e2Q2haCNSvdQCwL3AZwqPz4YSUSQVQgihkiiSCiGEUMk8WSS1zDLLeMSIES1Z90svvcQiiyzSknX3R8TVO50YVyfGBBFXb3RiTFAtrsmTJz9re9nSRO6A9kma/Rk1apRb5YYbbmjZuvsj4uqdToyrE2OyI67e6MSY7GpxAZMcbUmFEEJohsgwQgghVBIZRgghhEoiwwghhFBJwwxD0sa5FUok7Srp2NzKZQghhEGkyh3GL4GXJa1DauDrIXrXN0MIIYR5QJUMY3Z+5Gpb4ETbJ5FaMQ0hhDCIVHlxb5akb5Galf5obt2xXu9XIYQQ5lFV7jB2IrUVv5ftf5F6p/pp+SIhhBDmNQ3vMHImcWxh/J9EHUZosxGHXtWv5c/csvOabwih01V5Smp7SQ9KminpRUmzco9hIYQQBpEqdRhHA9vYvq/VwYQQQuhcVeowZkRmEUIIocodxiRJFwK/o9BRuu1LWxVUCCGEzlMlw1gMeBn4RGGagcgwQghhEKnylNSeAxFICCGEzlblKakVJV0m6en8uUTSigMRXAghhM5RpdL7DOByYPn8uSJPCyGEMIhUyTCWtX2G7dn5cyZQ3u9rCCGEeU6VDOO53Kz5kPzZFXiu1YGFEELoLFUyjC8COwL/Ap4CdgCiIjyEEAaZKk9JPQp8egBiCSGE0MHqZhiSvmH7aEknkN67eBvbB7Q0shBCCB2l7A6j1hzIpIEIRNJCwE3AgqS4Lrb9fUmrAuOBpYHJwG62/zMQMYUQQpijboZh+4o8+LLti4rzJH2uBbG8Bmxmu0vSUODPkq4BvgocZ3u8pFOAvUjdxoYQQhhAVSq9v1VxWr846cqjQ/PHwGbAxXn6WcBnmr3tEEIIjSl1193DDGkr4JOkJ6QuLMxaDFjL9vpND0YaQip2eg9wEqlnv9tsvyfPXwm4xvYHelh2b2BvgOHDh48aP358s8MDoKuri2HDhrVk3f0x2OKa9sTMfi2/6uJDOu54DbbvsL86Ma5OjAmqxTV27NjJtkeXpSmrw3iSVH/xadKPeM0s4OCKcfaK7TeAdSUtAVwGrNmLZU8FTgUYPXq0x4wZ04oQmThxIq1ad38MtrjGNaHHvU47XoPtO+yvToyrE2OC5sVVVocxFZgq6Xzbr/d7S71g+wVJNwAbAUtImt/2bFJ/4k8MZCwhhBCSKnUYIyRdLOleSQ/XPs0ORNKy+c4CSQsDm5Oe1LqB9LIgwB7A75u97RBCCI1VbXzwl8BsYCxwNnBuC2JZDrhB0l3A34AJtq8Evgl8VdI/SI/WntaCbYcQQmigSgdKC9u+TpLyW9+HSZoMfK+Zgdi+C1ivh+kPA02vYA8hhNA7VTKM1yTNBzwoaT9SHULnPQYQQgihpaoUSR0IvAM4ABgF7EaqSwghhDCIVGl88G95sItopTaEEAathhmGpDWArwOrFNPb3qyFcYUQQugwVeowLgJOAX4NvNHacELofCP68dLg9CO3bmIkIQysKhnGbNvR2F8IIQxyVSq9r5D0FUnLSVqq9ml5ZCGEEDpKlTuM2hNRXy9MM7Ba88MJIYTQqao8JbXqQAQSQgihs5V10bqZ7eslbd/TfNuXti6sEEIInabsDmNT4Hpgmx7mGYgMI4QQBpGy5s2/n//Gy3ohhBAaPyUlaWlJx0uaImmypF9IWnogggshhNA5qjxWOx54BvgsqV+KZ3h7l60hhBAGgSqP1S5n+0eF8cMl7dSqgEIIIXSmKncYf5T0eUnz5c+OwLWtDiyEEEJnKXusdhbpaSgBBzGnl735SC3Xfq1k2SWB5YFXgOm232xSvCGEENqk7CmpRXuzIkmLA/sCOwMLkOo6FgKGS7oNONn2Df2INYQQQhtVqcNA0trACN7evHn39zAuJvX3vYntF7otPwrYTdJqtqNP7hBCmAtV6Q/jdGBt4B6gVrT0Xy/u2d683jpsTwYm9z3MEEII7VblDmND22tVXaGkc4EbgZtt39/nyEIIIXSUKk9J3SqpcoYBnAYsB5wg6WFJl0g6sG/hhRBC6BRVMoyzSZnGA5LukjRN0l31EueK7SOA75J66RsN7NNoI5JWknSDpHsl3VPLZCQdJukJSXfmzycr7VkIIYSmqlIkdRqwGzCNOXUYdUm6DlgEuBW4GfiQ7acrbGc2cIjtKZIWBSZLmpDnHWf7ZxXWEUIIoUWqZBjP2L68F+u8CxgFfACYCbwg6Vbbr5QtZPsp4Kk8PEvSfcAKvdhuCCGEFpLt8gTSycASwBXAa7XpjfrDyHcJ40gv+L3L9oKVg5JGADeRMp2v5vW8CEwi3YU838MyewN7AwwfPnzU+PHjq26uV7q6uhg2bFhL1t0fgy2uaU/M7Nfyqy4+pM9x9WfbI1dYvO68wfYd9lcnxtWJMUG1uMaOHTvZ9uiyNFUyjDN6mGzbX6yTfj9gE9JdxnRSsdTNtq8v3dCc5YeRnrI6wvalkoYDz5Ie5f0RqW2rHrddM3r0aE+aNKnK5npt4sSJjBkzpiXr7o/BFteIQ6/q1/JnbrlIn+Pqz7anH7l13XmD7Tvsr06MqxNjgmpxSWqYYVTporW3/WEsBBwLTLY9uzcLShoKXAKcV7uDsT2jMP/XwJW9jCeEEEITVOkPY0VJl0l6On8ukbRivfS2f2b7dmApSSvXPhW2I1IF+322jy1MX66QbDvg7kbrCiGE0HxVHqs9A7ic1Jjg8qS6jJ6KqQCQtI2kB4FHSEVL04FrKmxnY9LTWJt1e4T26MKjvGOBgyusK4QQQpNVeUpqWdvFDOJMSQeVpD8c2BD4k+31JI0Fdm20Edt/JrWM293VFWIMIYTQYlUyjOck7QpckMd3Bp4rSf+67edq/WfYvkHSz/sbaAjNNO2JmYzrZ8V5CINNlQzji8AJwHGkJ5X+ApRVhL+Qn3S6CThP0tPAS/0NNIQQQntVeUrqUeDTvVjntqSOkw4GdgEWB37Yp+hCCCF0jCpPSZ0laYnC+JK5yfOe0g4BrrT9pu3Zts+yfbztsiKsEEIIc4EqT0mtXewQKb9lvV5PCW2/AbyZe98LIYQwD6lShzGfpCVrzXFIWqrBcl3AtNxw4Ft1F7YP6FekIYQQ2qpKhnEMqXnzi/L450jNl9dzKd164wshhDD3q1LpfbakScBmedL2tu8tSX9Ws4ILIYTQOarcYZAziLqZBICkaaTHbuutY+3ehRZCCKGTVMowKvpU/rtv/ntO/rsrJRlJCCGEuUPTMoz8vgaSNrddfIrqm5KmAIc2a1shhBAGXmmGIWn+WhPl+e3tNYGHbf+7fDFtbPuWPPJhqj2+GwaZ/vZpEUIYWHV/yCWNA2ZI+rukrUhdrx4FTJW0c8k69wJOljRd0nTgZFLzIiGEEOZiZXcYhwDvBRYFpgLr2X4o94A3gTmNEb6N7cnAOrWX92z3ry/NEEIIHaEsw3jD9rPAs5K6bD8EqQe81NdRucgoQghh3lKWYfxT0k9Idxj3SzqG9ELex4GnBiK4EEIInaOsMnpX4EXgcVJrtbcC3wKGA+NaHlkIIYSOUvcOw/aLwE8Kky7On16RNBp40vaTvQ8vhBBCpyh7Smq0pBsknStpJUkTJL0g6W+Semytto79gaskXdj/cEMIIbRLWR3GycD3gSVIvewdbHtzSR/L8zaqsgHbewBIWrR/oYYQQminsjqMobavsX0BYNsXkwauAxaqt5CSXSV9L4+vLGl927OaGnkIIYQBVZZhvCrpE5I+B1jSZwAkbQq8UbJc7e6j9nLfLOCkJsQaQgihjcqKpL4MHA28CWwB7CPpTOAJYO+S5Taw/UFJd0DqoU/SAk2KN4QQQpuUPSU1lZRR1ByYP428nvv2NoCkZUmZTilJKwFnkx7bNXCq7V/kHv4uBEYA04Eda73/hRBCGDiljQJKWlPSx3LDg8XpW5YsdjxwGfBOSUcAfwZ+XCGW2cAhttcCNgT2lbQWqZXb62yvDlxHtHobQghtUfZY7QHA70mPxd4tadvC7LoZgO3zgG+Q3uF4CviM7YvqpS8s95TtKXl4FnAfsAKwLVDrxe8s4DON1hVCCKH5ZPfct1HuQW8j212SRpBe2jsnFxPd0a3Pi+JyS/UweZbt1ysHlbZ3E/AB4J+2l8jTBTxfG++2zN7kupXhw4ePGj9+fNXN9UpXVxfDhg1rnHCAzY1xTXuifc2NDV8YZrwy8NsducLidefNjd9hO3ViXJ0YE1SLa+zYsZNtjy5LU1bpPZ/tLgDb0yWNAS6WtApQ1vrgFGAl4PmcbgngX5JmAP+TW7OtKxd/XQIcZPvFYkOHti2pxxzO9qnAqQCjR4/2mDFjyjbTZxMnTqRV6+6PuTGucW3sD+OQkbM5ZlozO5ysZvouY+rOmxu/w3bqxLg6MSZoXlxldRgzJK1bG8mZx6eAZYCRJctNAD5pexnbSwNbAVcCXyE9cluXpKGkzOI825cW4lguz18OeLp0j0IIIbREWYaxO/Cv4gTbs23vDny0ZLkNbV9bWOaPpKKt24AF6y2Ui5tOA+6zfWxh1uXAHnl4D1K9SgghhAFW9ljt4yXzbilZ51OSvgnUKhF2It0lDKH88dqNgd2AaZLuzNO+DRwJ/FbSXsCjwI4l6wghhNAirSjE/QKpDarf5fFb8rQhlPzY2/4z9etGPtbE+EIIIfRB0zOM3Evf/nVm/6PZ2wshhDAwSjOMXIz0J9tjq64wv9n9DeD9FBoptL1ZX4MMYV4xouTJsENGzi59cmz6kVu3IqQQKit909v2G8Cbkuo/PP7fzgPuB1YFfkBqzuNvfQ0whBBCZ6hSJNVFqoieALxUm2j7gDrpl7Z9mqQDbd8I3CgpMowQQpjLVckwLs2fqmpvdD8laWvgSaCnt79DCCHMRRpmGLbPkrQwsLLtByqs8/BchHUIcAKwGHBw/8IMIYTQbg0zDEnbAD8DFgBWzW9//9D2p3tKb/vKPDgTqFxZHkIIobOVVnpnhwHrAy8A2L4TWK1lEYUQQuhIVTKM1213b1a0YYdIIYQQ5i1VKr3vkfQFYIik1YEDgL+0NqwQQgidpsodxv6kl/BeA84n1U0cVHUDkraVtEGfogshhNAxqtxhrGn7/4D/6+M2NgBGSprf9lZ9XEcIIYQ2q5JhHCPpXaQe9y60fXdvNmD7232KLIQQQkdpWCSV25EaCzwD/ErSNEnfqZde0o8kzV8YX0zSGU2JNoQQQttUqcPA9r9sHw98GbgT+F5J8vmB2yWtLWlzUjtSpd2yhhBC6HxVXtx7H6kTpB2AZ4ELSW9x98j2tyT9Cbid1K/3R21Hs+YhhDCXq1KHcTqp97xP2H6yUWJJHwWOB35I6vv7BEl7VVk2hBBC56rSltRGkhYA1pC0FPCA7ddLFvkZ8Dnb9wJI2h64HlizGQGHzlLWvwM07uMhhDD3qFIktSlwNqlfCwErSdrD9k11Ftko96MBgO1LJd3YjGBDCCG0T5VK72NJxVGb2v4osAVwXEn6d0u6TtLdAJLWBvbpf6ghhBDaqUqGMbTYrLntvwNDS9L/GvgWuV8M23cBn+9PkCGEENqvSqX3JEm/Ac7N47sAk0rSv8P2XyUVp83uY3whhBA6RJUMYx9gX1KjgwA3AyeXpH9W0rsBA0jaAXiqP0GGEEJovypPSb1Gqsc4tuI69wVOBdaU9ATwCLBro4UknQ58Cnja9gfytMOA/yG9ZQ7wbdtXV4wjhHlKoyfSykw/cusmRhIGqyp3GL1i+2Hg45IWAeazPaviomcCJ5KeyCo6zvbPmhhiCCGEPqjUNEhvSDpQ0mLAy8BxkqZI+kSj5fJjuv9udjwhhBCaQ7bLE0gjbU+rvEJpqu11JG1BanvqO8A5tj9YYdkRwJXdiqTGAS+SKtoPsf18nWX3BvYGGD58+Kjx48dXDblXurq6GDZsWEvW3R/timvaE907Y3y74QvDjFcGKJhe6MS4WhnTyBUW7/Oycc5X14kxQbW4xo4dO9n26LI0VTKMm4EFSUVG5/XQXWv39HfZXlvSL4CJti+TdIft9Uo3RI8ZxnBS+1UGfgQsZ/uLjdYzevRoT5pU9iBX302cOJExY8a0ZN390a64qrzpfcy0ppd89lsnxtXKmPpThxHnfHWdGBNUi0tSwwyjSvPmm5AepV0JmCzp/NwKbT2TJf0R+CRwraRF6WMf4LZn2H7D9puk9zvW78t6Qggh9F+lyxnbD+Y+MCaRGhZcT+lFi2/bvrRb8r2AdYGHbb8saWlgz74EJ2k527VHcrcDetV5UwghhOap0pbU2qQf/K2BCcA2tqdIWh64FXhbhpHvBqYUxp8DnquwnQuAMcAykh4Hvg+MkbQuqUhqOvC/VXYqhBBC81W5wzgB+A3pbuKtKjnbT5b1vNdbtnfuYfJpzVp/CCGE/qnyWO1lts8pZhaSDgSwfU7LIgshhNBRqmQYu/cwbVyT4wghhNDh6hZJSdoZ+AKwqqTLC7MWpRcv2Em6Lw+eZPvEPkUZQuiX/jQrcsjI2YxpXihhLlZWh/EXUqOBywDHFKbPAu6qugHb78tPSm3YpwhDCCF0hLoZhu1HgUeBjaquTNIQ4E+2x3Zb13NA9NMZQghzsbp1GJL+nP/OkvRi4TNL0os9LZO7Zn1TUt/bIQghhNCRyu4wPpL/LtrLdXYB0yRNAF4qrO+A+ouEEELodFVe3Hs38Ljt1ySNAdYGzrb9Qp1FLqXby3whhBDmflVe3LsEGC3pPaSOkX4PnE9qK+q/2D6reeGFEELoFFUyjDdtz5a0HXCC7RMk3VEvsaTVgZ8AawEL1abbXq3f0YYQQmibKi/uvZ7fydgDuDJPG1qS/gzgl8BsYCypB71z+xNkCCGE9quSYexJerT2CNuPSFoVKGsSZGHb15H62njU9mGkhgtDCCHMxRoWSdm+FzigMP4IcFTJIq9Jmg94UNJ+wBNA53VBFUIIoVeqPCW1MXAYsEpOL8AldRIHAu8gZTI/IhVL7dGMYENr9KfZiDA49Occ6U9vf6GzVKn0Pg04GJgMvNEose2/AUh603afOk4KIYTQearUYcy0fY3tp20/V/vUSyxpI0n3Avfn8XUkndysgEMIIbRHlTuMGyT9lPQy3mu1iban1En/c2AL4PKcbqqkj/YzzhBCCG1WJcPYIP8dXZhmYLN6C9h+LHX5/ZaGRVkhhBA6W5WnpMY2StPNY5I+DFjSUFIl+H0NlgkhhNDhGtZhSBou6TRJ1+TxtSTtVbLIl4F9gRVIj9Sum8dDCCHMxapUep8JXAssn8f/DhxUkt62d7E93PY7be9aVkkeQghh7lAlw1jG9m+BNwFsz6a8TuI2SRdJ2krdKjJCCCHMvapkGC/lLlYNIGlDYGZJ+jVIrdruTnrb+8eS1mi0EUmnS3pa0t2FaUtJmiDpwfx3yQrxhhBCaIEqT0l9lfSI7Lsl3QIsC+xQL7FtAxOACZLGkhoe/IqkqcChtm+ts+iZwImkxgprDgWus32kpEPz+DcrxDyojDj0Kg4ZOZtx8cZ2CKGFqjwlNUXSpsB7Sc2CPGD79Xrp893IrsBuwAxgf1KGsy5wEbBqne3cJGlEt8nbAmPy8FnARCLDCCGEtlC6IehhhrR92YK2e+xVT9LfSa3ZnmH78W7zvmm7bsOFOcO40vYH8vgLtpfIwwKer433sOzewN4Aw4cPHzV+/Piy8Pusq6uLYcM6qy3FaU/MZPjCMOOVdkfy3yKu6joxJuh/XCNXWLx5wRR04v9iJ8YE1eIaO3bsZNujy9KUZRhn5MF3Ah8Grq+tF/iL7U/VWU6ut9IGyjKMPP687Yb1GKNHj/akSZP6EkJDEydOZMyYMS1Zd1/ViqSOmValhHFgRVzVdWJM0P+4WtX4YCf+L3ZiTFAtLkkNM4y6ld6298yNBw4F1rL9WdufBd5PDx0oSfq1pJE9ZRaSFpH0RUm7lEb832ZIWi6vYzng6V4uH0IIoUmqXDasZPupwvgMYOUe0p0EfFfSSOBu4BlSF62rA4sBpwPn9TK+y0lNox+Z//6+l8uHEEJokioZxnWSrgUuyOM7AX/qnsj2ncCOkoaR2p1aDngFuM/2A402IukCUgX3MpIeB75Pyih+m98sfxTYsUK8IYQOEn1pzDuqPCW1n6TtgFqLs6favqwkfRfpaaZesb1znVkf6+26QgghNF+lmqycQdTNJEIIIcz7qrzpHUIIITQvw5B0Tv57YLPWGUIIoXNUad58G0lVMpZRkpYHvihpydwO1Fuf/ocaQgihnarUYewE/FzSJcDptu+vk+4U4DpgNWAyqRmRGufpIYQQ5lIN7xxs7wqsBzwEnCnpVkl7S1q0W7rjbb+PlKmsZnvVwicyixBCmMtVqsOw/SJwMTCe9H7FdsAUSfv3kHYfSetI2i9/1m5qxCGEENqiSh3GtpIuI71bMRRY3/ZWwDrAIT2kP4D0Rvc78+e8njKWEEIIc5cqdRjbA8fZvqk40fbLdfr2/hKwge2XACQdBdwKnNDfYEMIIbRPlQzjX90zC0lH2f6m7et6SC/e3oXrG7y9Ajz0oD/NJ4QQwkCoUoexeQ/TtipJfwZwu6TDJB0G3Aac1ofYQgghdJC6dxiS9gG+Quqa9a7CrEWBW+otZ/tYSROBj+RJe9q+owmxhhBCaKOyIqnzgWuAn5D60q6ZZfvfZSu1PQWY0v/wQgghdIqyDMO2p0vat/sMSUs1yjRCCCHMWxrdYXyK9Na2iTe3QwhhUKubYdT67La96sCFE0IIoVOVVXp/sGzBXE8RQghhkCgrkjqmZJ6BzZocSwghhA5WViQ1diADCSGE0NnKiqQ2s329pO17mm/70taFFUIIodOUFUltClwPbNPDPAORYYQQwiBSViT1/fx3z4ELJ4QQQqeq0rz50pKOlzRF0mRJv5C09EAEF0IIoXNUaXxwPPAM8Flghzx8YSuD6k7SdEnTJN0padJAbjuEEEJSpXnz5Wz/qDB+uKSdWhVQibG2n23DdkMIIVDtDuOPkj4vab782RG4ttWBhRBC6Cyy3fMMaRZz2pBaBHgzz5oP6LK92IBEmGJ5BHg+x/Mr26f2kGZvYG+A4cOHjxo/fnxLYunq6mLYsGFNX++0J2b2a/nhC8OMV5oUTBNFXNV1YkzQ3rhGrrB43Xmt+l/sj06MCarFNXbs2Mm2R5elqZthdBJJK9h+QtI7gQnA/t17ASwaPXq0J01qTVXHxIkTGTNmTNPX298e9w4ZOZtjplUpYRxYEVd1nRgTtDeu6UduXXdeq/4X+6MTY4JqcUlqmGFUOgskLQmsDixUm1b2g91stp/If5+WdBmwPjBg2w8hhFAhw5D0JeBAYEXgTmBD4FYGqC0pSYsA89melYc/AfxwILYdQghhjiqV3gcCHwIeze1LrQe80MqguhkO/FnSVOCvwFW2/zCA2w8hhEC1IqlXbb8qCUkL2r5f0ntbHllm+2FgnYHaXn/0tx4ihNA87fh/PGTkbMYdelVp3cvcrEqG8bikJYDfARMkPQ882sqgQgghdJ6GGYbt7fLgYZJuABYHokgohBAGmapPSX0Q+AjpPYhbbP+npVGFEELoOFUaH/wecBawNLAMcIak77Q6sBBCCJ2lyh3GLsA6tl8FkHQk6fHaw1sYV9s0qiirVWqFEMJgU+Wx2icpvLAHLAg80ZpwQgghdKqyLlpPINVZzATukTQhj29Oeh8ihBDCIFJWJFVrjGkycFlh+sSWRRNCCKFjlXXRelZtWNICwBp59AHbr7c6sBBCCJ2lSltSY0hPSU0nNXW+kqQ9BrLxwRDC4FT2EEonP4DSrlYfWv2GeZWnpI4BPmH7AQBJawAXAKNaGVgIIYTOUuUpqaG1zALA9t+Boa0LKYQQQieqcocxWdJvgHPz+C7MqRAPIYQwSFTJML4M7AsckMdvBk5uWUQhhBA6UmmGIWkIMNX2msCxAxNSCCGETlRah2H7DeABSSsPUDwhhBA6VJUiqSVJb3r/FXipNtH2p1sWVQghhI5TJcP4bsujCCGE0PHK2pJaiFTh/R5gGnCa7dkDFVgIIYTOUlaHcRYwmpRZbEV6gS+EEMIgVVYktZbtkQCSTiNaqA0hhEGt7A7jrQYGoygqhBBC2R3GOpJezMMCFs7jAmx7sZZHF0IIoWPUvcOwPcT2YvmzqO35C8MDmllI2lLSA5L+IenQgdx2CCGEpErjg22V3zY/iVTxvhaws6S12htVCCEMPh2fYQDrA/+w/bDt/wDjgW3bHFMIIQw6st3uGEpJ2gHY0vaX8vhuwAa29+uWbm9g7zz6XuABWmMZ4NkWrbs/Iq7e6cS4OjEmiLh6oxNjgmpxrWJ72bIEVd70nivYPhU4tdXbkTTJ9uhWb6e3Iq7e6cS4OjEmiLh6oxNjgubFNTcUST0BrFQYXzFPCyGEMIDmhgzjb8DqklaVtADweeDyNscUQgiDTscXSdmeLWk/4FpgCHC67XvaGFLLi736KOLqnU6MqxNjgoirNzoxJmhSXB1f6R1CCKEzzA1FUiGEEDpAZBghhBAqiQwjk3S6pKcl3V1nviQdn5snuUvSBwvz/iDpBUlXdkpcktaVdKuke/L0nTokrlUkTZF0Z47ty50QV2H+YpIel3RiJ8Qk6Y18rO6U1NSHPfoZ18qS/ijpPkn3ShrR7rgkjS0cqzslvSrpM+2MKc87Op/r9+U0akZMTYjrKEl350+13wfb8Un1OB8FPgjcXWf+J4FrSI0vbgjcXpj3MWAb4MpOiQtYA1g9Dy8PPAUs0QFxLQAsmIeHAdOB5dsdV2H+L4DzgRM7ISagq9nnVJPimghsXvge39EJcRXSLAX8u1lx9eN8/zBwC+mBnSHArcCYdh8rYGtgAunBp0VIT6Mu1mh7cYeR2b6JdILVsy1wtpPbgCUkLZeXvQ6Y1Ulx2f677QfzOp4EngZK3+IcoLj+Y/u1nGZBmnyX25/vUdIoYDjwx06JqZX6GpdSW27z256Q19Nl++V2x9UtzQ7ANc2Kqx8xGViIfKEEDAVmNCOmfsa1FnCT7dm2XwLuArZstL3IMKpbAXisMP54ntZuDeOStD7phH2oE+KStJKku/L8o3KG1ta4JM1H6lXyawMYS2lMeXghSZMk3das4pUmxLUG8IKkSyXdIemnSo2Etjuuos8DFwxYRHVisn0rcAPpDv8p4Frb97U7LmAqsKWkd0haBhjL21+Q7lFkGPO4fDVxDrCn7TfbHQ+A7cdsr03qL34PScPbHRPwFeBq24+3O5BuVnFq0uELwM8lvbvdAZGKMTYhZa4fAlYDxrUzoKJ8zo8kvbvV7ljeA7yP1ELFCsBmkjZpb1Rg+4/A1cBfSBnrrcAbjZaLDKO6Tm2ipG5ckhYDrgL+L9+OdkRcNfnO4m7Sj0+749oI2E/SdOBnwO6SjmxzTNiu/X2YVG+w3gDFVBbX48CdTi1IzwZ+RypHb3dcNTsCl9l+nYFTL6btgNtysV0XqT5how6IC9tH2F7X9uakOo6/N1pZZBjVXU76EZGkDYGZtp9qd1DUiUupGZXLSOWXF3dQXCtKWhhA0pLAR2hdy8KV47K9i+2VbY8gXTmfbXugOuuqd6yWlLQgQC422Bi4d4BiqhsXqYJ0CUm1OrHNOiSump0Z2OKospj+CWwqaX5JQ4FNgYEskqp3bg2RtDSApLWBtalQd9fxTYMMFEkXAGOAZSQ9DnyfVEGF7VNIt2+fBP4BvAzsWVj2ZmBNYFhedi/bTbkd7kdcO5KeoFha0rg8bZztO9sc1/uAYySZdFXzM9vTmhFTP+NqmX4eq19JepN0cXek7ab9MPc1LttvSPoacF1+RHQy8Ot2x5WXHUG6or6xWfH0M6aLSRnqNFIF+B9sX9EBcQ0Fbk5fHy8Cu+a7xfLt5UesQgghhFJRJBVCCKGSyDBCCCFUEhlGCCGESiLDCCGEUElkGCGEECoZ1BmGJEs6tzA+v6RnlFudlfRpSYfm4cPyo4Td1zFCdVqKbHKs4yQtXxj/TW7TZ64jaaKkfndI3yqSxkj6cGH8y5J278Xyy0q6PTeb0aeXEiVtmNdxp1Irp4cV5n1GqeXR+5VaGt2hMO/M4nieNiKf6/sXpp1Ye9y6bFudLH9PTW8hel4jqatZ6xrs72G8BHxA0sK2XwE2p/DGqO3L6Zz+w8eR3op+EsD2lwZy45KG2G7YdMDcQtL8Jc+djwG6SM0m1J5n742PAdN68x31cHzPAna0PVWpnab35nTrkN5E39z2I5JWBf4k6RHbk0s28TRwoKRf2f5Pt3k9bqtd5rVzrRUanL8tM6jvMLKrSU39Qrc3RPNV/X/1iyBplKSpkqYC+/a0UkknSfp0Hr5M0ul5+IuSjsjDv5M0Wamt/L3ztCH5KvFuSdMkHZyvGEcD5+WrwIWLV+mSuiQdkWO6TbltJknvzuPTJB3e05VGvvq8X9J5+eryYknvyPOmK7WZPwX4nKRPKPWxMUXSRZKGSdpS0kWF9b111Sfpl0oN590j6Qd1jtN/rbOw7R/k6dMkrZmnD5N0Rp52l6TPlq2n27YmSvq5pEmkH89tCncCf5I0XOnFry8DB+djvYkKd5dK/Yzclrd9mdLb6sVtrAscDWxb+K52zvHeLemoQtouScfk86h7cxHvJDVWh+03Ci/sfQ34se1H8rxHgB8Dh/R0fAueAa4D9uhhXr1tFfdriKSf5X24S/luRdLH8vGbptQ3w4INzomy77v0XMvptszn6xRg+552NH8/7y+MT5Q0WtKmmtNXxh2SFi07YDmmZfLwaEkT8/BheV8nSnpY0gGFZXbPx2eqpHPytBGSrs/Tr1PqS2RxSY8qNXqJpEUkPSZpqNL/7R+UfhtuLpz7Z0o6RdLtwNEl6VbNx26apMPL9rHX3KK29ueGD+kqcm3S25gLAXeSri6vzPPHkftFAA4DvpaH7wI+mod/Sg9t0ZNay/xpHv4rqT0ZgDOALfLwUvnvwqS7h6WBUcCEwnqWyH8nAqML098aJ71Buk0ePhr4Th6+Etg5D3+ZHvpWAEbk5TfO46cX9nM68I08vAxwE7BIHv8m8D3SXeo/C9N/SXprtLh/Q3K8axdjr7fOwrb3z8NfAX6Th48Cfl6If8my9XTb14nAyd2Wrb28+iXgmO7fdZ3vftM8/MNiLIX045hz3iyfj8+y+VhdD3ym8L3tWOfc/B7wPKl5l/8FFsrTpwDrdEu7DqltJ4AzgR16+I7vJjUS+ED+Pk4kvflfd1vd1rEP6f9k/tp3S/qfeQxYI087Gzio3jlR4ftudK7Vtrc6qZWA39JDHzTAwcAP8vBywAN5+ArmnOfDavtS8vswHVgmD48GJhbOh7+QmitfBniO9Ob0+0ntMdWWWaqw3T3y8BeB3+Xh3wNj8/BOzDnHr2NOXzYbANcXvtsrgSEN0l0O7J6H96WJfaoM+jsM23eR/qF2Jt1tlJK0BOlH/KY86Zw6SW8GNlGqZ7gXmKHUiuZG5KIO4IB8dXkbqTmD1YGHgdUknSBpS9Jr+438h3QiQWqmYUQe3gioXemdX7L8Y7ZvycPnktp3qrkw/92Q1Ib+LZLuJF2pruJ0W/wHYBtJ85Pu1n6fl9kxXwneQfpn6l7n0uM6C/Mv7WGfPg6cVEtg+/kK6ym6sDC8InCtpGnA13OMdUlanPTd15qdOIvU/EqZD5F+aJ7Jx+q8wjJvAJf0tJDtH5J+pP5Iaqn2Dw2205BTA4a35/X1dlsfB36V9wHb/yYVXT1iu9Zo3VmkC6l650Sj76n0XCM1v/OI7Qedfg3PpWe/JfWHAamJnFpbarcAx+Y7giXcvyKdq2y/ZvtZUnHfcFITIBflabVjBOn/sPb/dw5z/r8uJGUUkC4wL8x3Uh8GLsr7/itSpldzkVPTLGXpNmZOSUm936c+Gex1GDWXk8qFx5Cu8vvN9hM5c9mSdLW0FOnk7bI9S9IY0j/hRrZfzre7C9l+XqmcegvSXcGOpKuSMq/nfyBIP0K9/V67tw9THH8p/xXpzmfnHpYfD+xH6shlUt6/VcnNX+d9OpN0hVhUtk6AWkdLjfap0XqKXioMnwAca/vy/H0cVmH5ZnrVJWX1th8Cfinp18AzSo3F3Uu6C51aSDoKmFRxmz8m/YC+ra2lnrZl+7nqu/JfejonGn1PpedaLu5rKP/vPafUqN5OpP8jbB8p6SpS20q3SNrC9v0lq5rNnGL77ufua4XhvvzPQfrd+bGkpUjf4fWk3u9esL1unWVqx2i+Bula0ubToL/DyE4n3cI2bATP9gukzmNqVwm7lCS/jXSLfhPpjuNr+S/A4sDzObNYk3RVVWuVdD7blwDfYU6z0bOA0jLXOtv/bB7+fEm6lSXVytC/APy5zro2Vmrfv1bmukaed2OO839IPxQAi5FO7plKdSpb9XKd9UygUG+kVIfQl/VA+g5qDzkUy/Z7PNa2ZwLPa86TT7vRuJG7v5JaK11GqUJ55wrLIGnr/AML6c7zDeAF0oXNt5T70M5/DyIVjTaUfyDvJXUp3GhbRROA/813DOQfuQeAEbXjztuPR0/nRNXvqV66+/P2an2ClF0gXAh8A1g8lyIg6d22p9k+itTi7poly0MqkhqVhz9bkq7melL9S60V2KXy9L8w5/9vF/JvgFNz538jdQt8pVP90YvAI5I+l9ehfAH5Ng3S3dJte00TGQZg+3Hbx/dikT2Bk/KtYFmH7jeTykn/QSp7Xoo5GcYfgPkl3QccSfongdTJysS87nOBb+XpZwKnKFekVozzIOCrSr3bvQeYWSfdA8C+OZYlSWXOb2P7GVLZ/AV5fbeS/+HyVfKVpEzhyjxtKqko6n7S7fgtvVlnicOBJZUqX6eSyoD7sh5IdxQXSZoMPFuYfgWwXT7W3R+L3QP4ad7OuqR6jLqcmrg+lNTr2lRgsu3fly2T7QY8kM+Dc4Bd8g/KnaQy/Ssk/Z1UZr6P7WIT8b+S9Hj+3NrDuo8gFceVbqvbMr8h1UvclY/7F2y/SvpfuCgX670JnJL3u6dzotL3VC9d3t7ewFW5qPPpkuN3MelH87eFaQfl8+Yu4HVS3xTk/e7JD4BfKD0k0fCpLdv3kI7tjfkYHZtn7Q/smbe7G3BgYbELSfU7xaLSXYC98jruIXWz2pN66Q4k/T9Po8m9gkZrtfMwpaedXrFtSZ8nVYBv2y3NCNLVzQfaEWPoH6VOnjYgPUjR/XHZEJoq6jDmbaOAE3Nxwws0rgsJcxkPXCdPIcQdRgghhGqiDiOEEEIlkWGEEEKoJDKMEEIIlUSGEUIIoZLIMEIIIVTy/6Kby4+ne3Q4AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "wasting_prevalence_ratio.query(\"wasting_state == 'mild_child_wasting'\").value.hist(bins=20, density=True)\n",
+    "plt.xlabel(\"Mild wasting prevalence ratio for SQLNS covered vs. uncovered\")\n",
+    "plt.ylabel(\"Probability density over 288 combinations\\nof (year, sex, age, draw)\")\n",
+    "plt.title(\"Mild wasting prevalence ratio historgrm\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "6909786f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "count    288.000000\n",
+       "mean       1.004119\n",
+       "std        0.006576\n",
+       "min        0.983561\n",
+       "2.5%       0.990485\n",
+       "50%        1.003811\n",
+       "97.5%      1.017270\n",
+       "max        1.021207\n",
+       "Name: value, dtype: float64"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wasting_prevalence_ratio.query(\n",
+    "    \"wasting_state == 'susceptible_to_child_wasting'\").value.describe(percentiles=[.025, .975])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "30cca8d0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYoAAAEWCAYAAAB42tAoAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAA58UlEQVR4nO3deZgU1dn38e8PcEGGTdAJIgpxjQluTIzGqDMY9zXGaIwLqHmIxj2axKyaRBM0jxo1UWPigiuo0UfU1y3ouG+gKC7BBdGIiCvKGKOi9/vHOQ1F011dM9PdU8D9ua6+uqvqVJ27q6v7dJ1TdY7MDOecc66cbl0dgHPOuXzzgsI551wqLyicc86l8oLCOedcKi8onHPOpfKCwjnnXCovKFzuSPq5pL93dRy1JOlSSad0dRzVJGkrSdM7uG6rpO+XWbaGpDZJ3TsXoesoLyjqLB7whcfnkj5KTO8v6WRJJumYovWOifNPjtPNcf02SfMkTZd0cNE6JunDojx/EpedLOmKur3xMuL7eC05z8x+b2YlfzRcfsTja+3CtJndZ2brVTsfM3vVzBrM7LMK8YyWdH+183deUNRdPOAbzKwBeBXYLTHvypjseeCgolVHxflJr8ft9AGOA/4mqfiLulEyTzM7vcpvaaklqUdXx9BVlsX33t73vCztIy8o8ukxYCVJXwaIzyvG+Yux4P8B7wIbVjMQSb+RdG58vVw8Q/ljnO4p6b+SVo7T10p6Q9L7ku4txB+X7Szp2Xj2M0vSCZJ6AbcCqyXOeFZLnu1IGhr/uY6S9KqktyX9IrHdnpLGSXpP0nOSflJ8hlL0fkzS0ZJmxG39UVK3uGy0pAcknSXpHeBkSStI+t+Y9xxJF0jqGdM/J2nXxLZ7SHpL0qaV9keJuHaVNFXSXEkPStowsWxm3F9PxW1NkLRiYvkecd0PJL0kacc4v6+kiyTNjvv8FJWpvon7/DpJV0j6ABgtaTNJD8WYZkv6s6TlY/p746pPxs9t3+KzQ0lfUqhSmivpGUm7l3v/0Zpx/8+TdIekgXE7hWOgR+JzmhHTvaxwJv4l4AJgixjP3MQ+uCx+Lq9I+mWFz3uApJvivnws7rMFZykxjiMkvQC8UHjP8bh7M+6nPRWO9+clvSvp5xXed+55QZFfl7PwrGJUnC5JUrf4JRwIvFjlOO4BmuPrrwJvAFvH6S2A6Wb2bpy+FVgHWBV4HLhy4Wa4CPiBmfUGvgLcZWYfAjsRz4zi4/UycXwDWA/YFvh1/GEAOAkYCnwR2A44IMN7+hbQBGwK7AEcklj2NWAG0AicCowF1gU2BtYGBgO/jmmvBvZLrLsD8LaZPR6n0/bHApI2AS4GfgAMAP4KTJS0QiLZPsCOwDDCn4HRcd3NgMuAHwP9CJ/NzLjOpcD8GPcmwPZAWpXeHsB1cTtXAp8RzlQHEj7rbYEfAphZ4RgonLFOKHpPywE3AXfE938UcKUWP+NN+h5wcEy/PHBCcQKFPxfnADvFY+nrwFQzew44DHgoxtMvrnIu0JdwfGxD+E4lq2iLP++/AB8CXyB870aViHPPuN4GcfoLhD9yhWPjb4TjcASwFfArScNS3nf+mZk/uuhB+EJ/s2jeycAVwBqEqqnl4vOQOP/kmK4Z+ByYC3xM+FIfW7QtAz6IaQqPHZL5ZIixJ/Bfwg/YicDPgdeABuA3wDll1usX8+8bp18l/BD2KUrXDLxWah/E10PjdlZPLH8U+G58PaPwnuL094u3V2Kf7JiY/iEwKb4eDbyaWCbCj8ZaiXlbAC/H12sD84CV4vSVwK8z7o9LgVPi6/OB3xWlnw5skzhODkgsOx24IL7+K3BWifwa43HRMzFvP+DuMvGdDNxb4Vg4FrihaF+uXeqzJPxAvgF0Syy/mnj8lth2K/DLos/ltqJjoAfQi3Acfzv53hKf3/2J6e7AJ8AGiXk/AFrLfN7dgU+B9RLzTinapgEji97zR0D3ON07pvlaIs0UYM9K37U8P/yMIqfM7FXC2cHvgRfM7N8lkr1u4Z9TH8K/rJEl0mxqZv0Sj9vbGcdHwGTCv7GtCWcYDwJbxnn3AEjqLmlsrPr4gIX/agfG528DOwOvSLpH0hbtiYPwo1PwH0JBBbAakNw3pfZTsWSaV+I2Si1bBVgJmBKrT+YCt8X5mNmLwHPAbpJWAnYHroJM+yNpTeD4Qh4xnyFFcZV7/0OAl8psczlgdmKbfyX8Wy9nkX0naV1JN8fqsw8Ix2Kp+EtZDfi3mX2emPcK4V93OeXe4wIWzkL3JZw9zJZ0i6T1y2xvIGEfvJISQ/Hn3YPKx1PxvHdsYUP7R/F5TmL5R5R4L0sSLyjy7TLg+Phclpl9DPwUGC5pzxrEcQ+hENqE0E5yD6GaZTOgUFf9PULVxTcJp/pD43zFGB8zsz0IP1T/B1xTCL+Tsc0GVk9MD8mwTjLNGkCyuisZz9uEL/mXEwVtXwsXEBQUqp/2AJ6NhQdU2B9F/g2cWlSgr2RmV2d4L/8G1ioz/2NgYGKbfcysbDsJi38W5wP/AtYxsz6Es8lS8ZfyOjCk0B4QrQHMyrh++SDNbjez7YBBMb6/FRYVJX2bcIawZkoMyXXeIlTVVTqelrkut72gyLcJhHrlayolNLNPgDNYWH+eRTdJKyYeK5RJdw+hbvfZmE8roYrnZTN7K6bpTfhheofwL/z3hZUlLR8bHPua2aeE6rDCP805wABJfdsRd9I1wM8k9Zc0GDgywzo/jumHAMcQ9vNi4r/hvwFnSVo1vpfBknZIJBtP+IwOJ55NRGX3Rwl/Aw6T9DUFvSTtIql3hvdyEXCwpG1jW9VgSeub2WxC+8AZkvrEZWtJ2ibDNpPv4QOgLf5rP7xo+RxC3X8pjxDOCn6icBFEM7AbYX91mKRGhcb7XoT928aix9Lqig3u8V/+NcCpknpLWhP4EaEKdzEx/fWERu2V4nsuvvpwmeQFRY6Z2Udm9s9Y/ZPFxcAaknZLzHtSi95H8afEsv0I/5gLj1JVGBCqmnqy8OzhWUK7xb2JNJcRTutnxeUPF23jQGBmrMI4DNg/vsd/Ef6Vz4hVJKvRPr8ltJm8DPyT0Bj7cYV1biTUG08FbiH82JbzU0IV4MMx9n8SGtWJ8c8GHiI0qiYLnEr7YwEzmwz8D/Bn4L2Y3+gK76Gw7qOExtmzgPcJhXrhH/RBhEbhZ+N2ryP8C8/qBMKZ0TxCYVZcoJ4MjIuf2z5FcX1CKBh2IvyzPw84KH7endGN8GP/OuEqv21YWIDdBTwDvCHp7TjvKEI70wzgfkJhfnHK9o8knAG+QbiA5GoqH09LPcXGFueWCpIOJzR0l/znLMkIVSnVvjrMLYUknQZ8wcxKXf20zPAzCrdEkzRI0paxamU9QpvODV0dl1sySVpf0oaxCnAz4FD8eGKZubPQLbWWJ1zNM4xw2eR4QjWHcx3Rm1DdtBqhzeMMQlXlMs2rnpxzzqXyqifnnHOplrqqp4EDB9rQoUPrkteHH35Ir1696pJXR+U9xrzHB/mP0ePrvLzHWI/4pkyZ8raZrVJyYVffGl7tx4gRI6xe7r777rrl1VF5jzHv8ZnlP0aPr/PyHmM94gMmm3fh4ZxzriO8oHDOOZfKCwrnnHOpvKBwzjmXqmJBEe967RVfHyDpzNi5VtVJOk5hJKynJV0dO6obJukRSS8qjOy1fC3yds45V1qWM4rzgf9I2ojQPcJLVOj2uiNiz59HA01m9hXCICLfBU4jDMyyNqFjs0OrnbdzzrnyshQU8+OlU3sAfzazvxBuc6+FHkBPhbFxVyKMNTCS0OslwDjCMITOOefqpGIXHpLuIYzqdTBhhLM3gSfNbHjVg5GOIYxb+xGhL/1jgIfj2QRx/IBb4xlHcr0xwBiAxsbGEePHd6rL+8za2tpoaMj3wFV5jzHv8UH+Y/T4Oi/vMdYjvpaWlilm1lRyYbkbLAoPwsDhPwK2itNrEPqVr+qNckB/Qn/yqxCGL/w/wgDlLybSDAGeTtuO33C3qLzHmPf4zPIfo8fXeXmPsatvuKvYhYeZvQGcmZh+lRq0URCGjHzZ4ohpkq4njMvcT1IPMysMUdjpoRSd6ypDT7ylw+vOHLtLFSNxLrssVz3tJekFSe9L+kDSvDjSV7W9CmwehyAUsC1hZK67gb1jmlF4l7/OOVdXWRqzTwd2tzCofB8z621hoPWqMrNHCI3WjwPTYmwXEoai/JGkF4EBpA9b6Zxzrsqy9B47x8yeq3kkgJmdBJxUNHsGsFk98nfOObe4LAXFZEkTCI3LCwYZN7PraxWUc865/MhSUPQB/gNsn5hngBcUzjm3DMhy1dPB9QjEOedcPmW56ml1STdIejM+/iFp9XoE55xzrutluerpEmAisFp83BTnOeecWwZkKShWMbNLzGx+fFxKuHvaOefcMiBLQfFO7F68e3wcALxT68Ccc87lQ5aC4hBgH+ANQm+uexM6CHTOObcMyHLV0yvA7nWIxTnnXA6VLSgk/cTMTpd0LuG+iUWY2dE1jcw551wupJ1RFLrtmFyPQJxzzuVT2YLCzG6KL/9jZtcml0n6Tk2jcs45lxtZGrN/lnGec865pVBaG8VOwM7AYEnnJBb1AebXOjDnnHP5kNZG8TqhfWJ3YEpi/jzguFoG5ZxzLj/S2iieBJ6UdJWZfVrHmJxzzuVIlm7Gh0r6A7ABsGJhppl9sWZROeecy42snQKeT2iXaAEuA66odiCS1pM0NfH4QNKxklaWdGcct/tOSf2rnbdzzrnyshQUPc1sEiAze8XMTgZ2qXYgZjbdzDY2s42BEYTBkm4ATgQmmdk6wKQ47Zxzrk6yFBQfS+oGvCDpSEnfAhpqHNe2wEux+5A9gHFx/jhgzxrn7ZxzLkFmi/XOsWgC6auEu7T7Ab8D+gKnm9nDNQtKuhh43Mz+LGmumfWL8wW8V5hOpB8DjAFobGwcMX78+FqFtoi2tjYaGmpdZnZO3mPMe3xQ3RinzXq/w+sOH9y35Py878O8xwf5j7Ee8bW0tEwxs6ZSyyoWFPUmaXnCpblfNrM5yYIiLn/PzMq2UzQ1NdnkyfXpdaS1tZXm5ua65NVReY8x7/FBdWMceuItHV535tjSNb5534d5jw/yH2M94pNUtqCoeNWTpHWBHwNrJtOb2ciqRbionQhnE3Pi9BxJg8xstqRBwJs1ytc551wJWS6PvRa4APgb8FltwwFgP+DqxPREYBQwNj7fWIcYnHPORVkKivlmdn7NIwEk9QK2A36QmD0WuEbSocArhEGUnHPO1UmWguImST8kXKr6cWGmmb1b7WDM7ENgQNG8dwhXQTmXC51pZ3BuSZSloBgVn3+cmGeA35ntnHPLgCxDoQ6rRyDOOefyKa2b8ZFmdpekvUotN7PraxeWc865vEg7o9gGuAvYrcQyA7ygcM65ZUBaN+MnxeeD6xeOc865vKnY15OkAZLOkfS4pCmSzpY0oNJ6zjnnlg5ZOgUcD7wFfBvYO76eUMugnHPO5UeWy2MHmdnvEtOnSNq3VgE555zLlyxnFHdI+q6kbvGxD3B7rQNzzjmXD2mXx84jXN0k4FgWjmrXDWgDTkhZtz+wGvARMNPMPq9SvM455+os7aqn3u3ZkKS+wBGETv2WJ7RlrAg0SnoYOM/M7u5ErM4557pAljYKJG0IDGXRbsaL76O4jjCe9lZmNrdo/RHAgZK+aGYXdSZg55xz9ZVlPIqLgQ2BZ4BCFdJiN9yZ2XbltmFmU4ApHQ/TOedcV8lyRrG5mW2QdYOSrgDuAe4zs391ODLnnHO5kOWqp4ckZS4ogIuAQcC5kmZI+oekYzoWnnPOua6W5YziMkJh8QZhPAoBZmYblkpsZndLuhf4KtACHAZ8GTi7OiE755yrpywFxUXAgcA0FrZRlCVpEtALeAi4D/iqmfk41845t4TKUlC8ZWYT27HNp4ARwFeA94G5kh4ys48qrSipH/D3uK4BhwDTCV2GDAVmAvuY2XvtiMc551wnZGmjeELSVZL2k7RX4VEusZkdZ2ZbA3sB7wCXAHMzxnM2cJuZrQ9sBDwHnAhMMrN1gElx2jnnXJ1kOaPoSWib2D4xr+x4FJKOBLYinFXMBC4mVEGlijfsbQ2MBjCzT4BPJO0BNMdk44BW4KcZ4nbOOVcFMrPqblA6gVAwTDGz+e1Yb2PgQuBZwtnEFOAYYJaZ9YtpBLxXmE6sOwYYA9DY2Dhi/PjxnX4fWbS1tdHQ0FCXvDoq7zHmPT5YPMZps97vkjiGD+5bcn7e92He44P8x1iP+FpaWqaYWVOpZRULCkmrA+cCW8ZZ9wHHmNlrFdZbldCFBwBm9mqF9E3Aw8CWZvaIpLOBD4CjkgWDpPfMrH+57TQ1NdnkyZNT31O1tLa20tzcXJe8OirvMeY9Plg8xqEn3tIlccwcu0vJ+Xnfh3mPD/IfYz3ik1S2oMjSRnEJMJHQyd9qwE1xXrnMdpP0AvAy4ca7mcCtGfJ5DXjNzB6J09cBmwJzJA2K2x4E+BVUzjlXR1kKilXM7BIzmx8flwKrpKQ/BdgceN7MhgHbEs4UUpnZG8C/Ja0XZ21LqIaaCIyK80YBN2aI2TnnXJVkacx+R9IBwNVxej/C1UzlfGpm7xTGr4g34P0pYzxHAVdKWh6YARxMKMyukXQo8AqwT8ZtOeecq4IsBcUhhDaKswhXOz1I+AEvZ66kBuBewo/+m8CHWYIxs6lAqTqybbOs75xzrvoqFhRm9gqwezu2uQdhwKLjgP2BvsBvOxSdc865LlexjULSuHjHdGG6f+x6vFTa7sDNZvZ5bM8YZ2bnmFlaVZVzzrkcy9KYvWFyIKLYfcYmpRKa2WfA5/HmOeecc0uBLG0U3ST1L/SvJGnlCuu1AdMk3UmibcLMju5UpM4557pEloLiDEI349fG6e8Ap6akv54y3Xs455xb8mRpzL5M0mRgZJy1l5k9m5J+XLWCc8451/WynFEQC4ayhQOApGmEy2fLbaPkQEfOOefyLVNBkdGu8fmI+Hx5fD6AlALEOedcvlWtoIj3WyBpOzNLXhX1U0mP4+NIOOfcEin18lhJPRKvGyQ1xaueKqymLRMTX6+Uj3POufwq+wMuaTSh59bnJe1EGOL0NOBJSfulbPNQ4DxJMyXNBM4jdAPinHNuCZRW9XQ8sB7QG3gS2MTMXpLUCNzJwk4CF2FmU4CNCjfdmVnXjPLinHOuKtIKis/M7G3gbUltZvYSgJnNCQPNpfMCwjnnlg5pBcWrkv5AOKP4l6QzCDfSfROYXY/gnHPOdb20RuYDCEORvkboPfYh4GdAIzC65pE555zLhbJnFGb2AfCHxKzr4qNd4ljYr5vZ6+0PzznnXFdLu+qpSdLdkq6QNETSnZLmSnpMUsneY8s4CrhF0oTOh+ucc67e0toozgNOAvoRRrU7zsy2k7RtXLZFlgzMbBSApN6V0sbLaecBnwHzzaxw38YEYCgwE9in0JOtc8652ktro1jOzG41s6sBM7PrCC8mASuWW0nBAZJ+HafXkLSZmc3LGFOLmW1sZoUhUU8EJpnZOsAk/A5v55yrq7SC4r+Stpf0HcAk7QkgaRvCP/5yCmcbhZvy5gF/6USMewCFHmnHAXt2YlvOOefaSWal++uTtBFwOvA5Yfzrw4FRwCxgjJk9UGa9x81sU0lPFPp8kvSkmW1UMRjpZeA9QieCfzWzCyXNNbN+cbmA9wrTifXGAGMAGhsbR4wfP77iG6+GtrY2Ghoa6pJXR+U9xrzHB4vHOG1W19wiNHxw6YEj874P8x4f5D/GesTX0tIyJVGTs4iyBUVHSXoE+DrwWCwwVgHuKOoosNy6g81slqRVCXd/HwVMTBYMkt4zs/7lttHU1GSTJ0/u9PvIorW1lebm5rrk1VF5jzHv8cHiMQ498ZYuiWPm2F1Kzs+yDzsTc7l8s1oSP+O8qUd8ksoWFJU6BVxf0raSGorm75iy2jnADcCqkk4F7gd+nyVQM5sVn9+M29iM0N/UoJjvIODNLNtyzjlXHWmXxx4N3Ej4V/+0pD0Si8v+8JvZlcBPCPdgzAb2NLNry6VP5NercGWUpF7A9sDTwERClRfx+cZK23LOOVc9aZfH/g8wwszaJA0FrpM01MzOBsp29hQvZ32TRKeBkpYzs08rxNII3BD7keoBXGVmt0l6DLhG0qHAK8A+Gd6Xc865KkkrKLqZWRuAmc2U1EwoLNYkpaAAHgeGEBqlRbgP4w1Jc4D/ib3LLsbMZgCLNXib2TvAthXfiXPOuZpIa6OYI2njwkQsNHYFBgLDU9a7E9jZzAaa2QBgJ+Bm4IeES2edc84tQdIKioOAN5IzzGy+mR0EbJ2y3uZmdntinTuALczsYWCFzgTrnHOu/tI6BXwtZVnJeyii2ZJ+ChRuZtiXcHbSnXBPhnPOuSVILcay/h6wOvB/8bFGnNcdb4h2zrklTlpjdofEUfGOKrP4xWrn59yyotxNc8cPn8/oLroJMItps97vcHydvdnPVUdqQRGri/5pZi1ZNxjvxP4J8GUSnQea2ciOBumcc67rpFY9mdlnwOeSSncyU9qVwL+AYcBvCF2DP9bRAJ1zznWtLFVPbcA0SXcCHxZmmtnRZdIPMLOLJB1jZvcA98Sb5pxzzi2BshQU18dHVoU7sGdL2gV4HVi5vYE555zLh4oFhZmNk9QTWMPMpmfY5imxqup44FygD6Gbcudyob09qea9sdi5WqtYUEjaDfhfYHlgWLxb+7dmtnup9GZ2c3z5PpC5Edw551w+ZbmP4mRCd99zAcxsKvDFmkXknHMuV7IUFJ+aWfGQXn6HtXPOLSOyNGY/I+l7QHdJ6wBHAw/WNiznnHN5keWM4ijCzXMfA1cR2h6OzZqBpD0kfa1D0TnnnOtyWc4o1jezXwC/6GAeXwOGS+phZjt1cBvOOee6SJaC4gxJXwCuAyaY2dPtycDMft6hyJxzzuVCxaqn2M9TC/AW8FdJ0yT9slx6Sb+T1CMx3UfSJVmCkdRd0hOSbo7TwyQ9IulFSRMkLZ9lO84556onUzfjZvaGmZ0DHAZMBX6dkrwH8IikDSVtR+jnqeTwpyUcAzyXmD4NOMvM1iYMrXpoxu0455yrkiw33H2JMPjQ3sDbwATCXdclmdnPJP0TeITw4761mVXsXlzS6sAuwKnAjyQJGEkYywJgHOGejvMrbcs5Vz3tvZO92PFpAye7JYLMLD2B9BBhtLprzez1ihuUtib8mF9BGFu7P3BopXUlXQf8AegNnACMBh6OZxNIGgLcamZfKbHuGGAMQGNj44jx48cXJ6mJtrY2Ghoa6pJXR+U9xq6Ib9qs4tuC0jX2hDkf1SiYKlia4xs+uD0dV3ecf0+gpaVlipk1lVqWpa+nLWLbwLqSVgamm9mnKav8L/AdM3sWQNJewF3A+uVWkLQr8KaZTZHUXCmmEjFeCFwI0NTUZM3N7d5Eh7S2tlKvvDoq7zF2RXzt7bfp+OHzOWNa1cf4qpqlOb6Z+zdXN5gy/HuSLkvV0zbAZYRxJQQMkTTKzO4ts8oWcRwLAMzsekn3VMhmS2B3STsTBjvqA5wN9IuX1c4nDK86q1K8zjnnqitLY/aZwPZmto2ZbQ3sAJyVkn4tSZMkPQ0gaUPg8LQMzOxnZra6mQ0FvgvcZWb7A3cT2kYARgE3ZojXOedcFWU5H1wu2b24mT0vabmU9H8Dfgz8NaZ/StJVwCkdiO+nwHhJpwBPABd1YBtuKdTZBlbnXHZZCorJkv5OaJwG2B+YnJJ+JTN7NFy0tMD8rAGZWSvQGl/PIPRc65xzrotkKSgOB44gdAYIcB9wXkr6tyWtBRiApL2B2Z0J0jnnXNfJctXTx4R2ijMzbvMIwhVI60uaBbwMHNDhCJ1zznWpql9TF6uLvimpF9DNzOZVOw/nnHP1k6kLj/aQdIykPsB/gLMkPS5p+2rn45xzrj4qFhSS2nsD/iFm9gGwPTAAOBAY24HYnHPO5UCWM4rzJD0q6YeSstxPX7jcaWfgMjN7JjHPOefcEiZLN+NbES6JHQJMkXRV7BW2nCmS7iAUFLdL6o2Pse2cc0usTI3ZZvZCHINiMnAOsEns3fXnZnZ9UfJDgY2BGWb2H0kDgIOrGLNzzrk6ytLX04aEH/pdgDuB3czscUmrAQ8BixQUZvY58Hhi+h3gnWoG7Zxzrn6ynFGcC/ydcPawoLNgM3s9baQ755xzS4csjdk3mNnlyUJC0jEAZnZ5zSJzzjmXC1kKioNKzBtd5Ticc87lVNmqJ0n7EYYhHSZpYmJRb+DdrBlIKoyB/Rcz+3OHonTOOddl0tooHiR05jcQOCMxfx7wVNYMzOxL8cqnzTsUoXPOuS5VtqAws1eAV4Atsm5MUnfgn2bWUrStdwAfQMA555ZAZdsoJN0fn+dJ+iDxmCfpg1LrxCFQP894B7dzzrklQNoZxTfic+92brMNmCbpTuDDxPaOLr+Kc865vMpyw91awGtm9rGkZmBDQh9Oc8uscj1FN+FlIWlF4F5ghRjXdWZ2kqRhwHhCB4NTgAPN7JP2bt8551zHZLnh7h9Ak6S1CQMS3QhcRejLaTFmNq6DsXwMjDSztjgm9/2SbgV+BJxlZuMlXUDoIuT8DubhnHOunbLcR/G5mc0HvgWca2Y/BgaVSyxpHUnXSXpW0ozCo1ImFrTFyeXiw4CRwHVx/jhgzwwxO+ecqxKZWXoC6RHgT8AvCP08vSzpaTP7Spn09wMnAWcBuxH6iepmZr+uGEy4amoKsDbwF+CPwMNmtnZcPgS4tThvSWOAMQCNjY0jxo8fXymrqmhra6OhoaEueXVU3mPsaHzTZr1fg2hKa+wJcz6qnK6rLM3xDR9cn+tiltbvSXu0tLRMMbOmUsuyVD0dDBwGnBoLiWFAWtcdPc1skiTFS2xPljQFqFhQxKumNpbUD7gBWD9DfJjZhYRqMZqamqy5uTnLap3W2tpKvfLqqLzH2NH4Rp9Yv6utjx8+nzOmVX3U4KpZmuObuX9zdYMpY2n9nlRLxU/PzJ4Fjk5MvwyclrLKx5K6AS9IOhKYBbSrKDSzuZLuJtzD0U9Sj1j9tXrcnnPOuTrJMhTqlpLulPR8bG94uUKbwzHASoTCZQRwADAqQz6rxDMJJPUEtgOeA+4G9o7JRhEa051zztVJlvPBi4DjCG0Hn1VKbGaPAUj63MzaM2DRIGBcbKfoBlxjZjdLehYYL+kU4IkYj3POuTrJUlC8b2a3Zt2gpC0IP+YNwBqSNgJ+YGY/TFvPzJ4CNikxfwawWdb8nXPOVVeWguJuSX8k3ET3cWGmmT1eJv2fgB2AiTHdk5K27mSczjnnukiWguJr8Tl52VTh/oaSzOzfYUjtBSpWWTnnnMunLFc9tVRKU+Tfkr4OWLzD+hhCo7RzzrklUJarnholXRS700DSBpIOTVnlMOAIYDDhUtaN47RzzrklUJYuPC4FbgdWi9PPA8empDcz29/MGs1sVTM7II5H4ZxzbgmUpaAYaGbXAJ8DxBvf0tocHpZ0raSdVNRQ4ZxzbsmTpaD4MA5lagCSNgfSOtpZl9CdxkGEu7N/L2ndTkfqnHOuS2S56ulHhEtd15L0ALAKC++UXoyFXgbvBO6U1AJcAfxQ0pPAiWb2UOfDds45Vy9Zrnp6XNI2wHqAgOlm9mm59PHs4wDgQGAOcBShoNkYuBYY1vmwnXPO1UvZgkLSXmUWrSsJMys3it1DhN5l9zSz1xLzJ8eBh5xzzi1B0s4odovPqwJfB+6K0y3Ag5Qf7nQ9KzPIhZml9TrrnHMuh8oWFIUO/STdAWxgZrPj9CDCJbOLkPQ34Bwzm1ZiWS9gX+BjM7uyOqE755yrhyyN2UMKhUQ0B1ijRLq/AL+SNBx4GngLWBFYB+gDXAx4IeGcc0uYLAXFJEm3A1fH6X2BfxYnMrOpwD6SGgj9Qg0CPgKeM7Pp1QnXOedcvWW56ulISd8CCj3AXmhmN6SkbwNaqxOec865rpZpINtYMJQtHJxzLm+GtmNc9eOHz19kHPaZY3epRUhLrCx3ZjvnnFuGVa2gkHR5fD6mg+sPkXS3pGclPVPYjqSV45jdL8Tn/tWK2TnnXGVZuhnfTVKWAmWEpNWAQyT1jz/wCx4Z1p8PHG9mGwCbA0dI2gA4EZhkZusAk+K0c865OslSAOxL6NzvdEnrp6S7gPBDvj4wpegxuVImZja7MLyqmc0jDHY0GNgDGBeTjQP2zBCzc865Ksly1dMBkvoA+wGXSjLgEuDq+INeSHcOcI6k883s8M4EJWkosAnwCNCYuI/jDaCxM9t2+TH0xFsWa0R0zuWPyvS2sXjC0NnfgYRBi54D1ibciX1uibQbAVvFyXvN7KnMAYX7MO4BTjWz6yXNNbN+ieXvmVn/onXGAGMAGhsbR4wfPz5rdp3S1tZGQ0NDXfLqqDzHOG3W+zT2hDkfdXUk6fIe49Ic3/DBfTuc77RZaaMhLKo4xs7kWwv1+B63tLRMMbOmUssqFhSS9gBGEwqGy4BxZvampJWAZ81saFH6owk/2oW+oL5FuPdisQKlRF7LATcDt5vZmXHedKDZzGbH7kNazWy9cttoamqyyZMr1nRVRWtrK83NzXXJq6PyHGPhjOKMaZmu0u4yeY9xaY6vM5eptvfy2GSMebs8th7fY0llC4osn95ewFlmdm9yppn9p8zY2d8HvmZmH8bMTyP0KJtaUMTR8C4i3Ml9ZmLRRGAUMDY+35ghZuecc1WSpTH7jeJCIv74Y2aTSqQXiw6V+lmcV8mWhKqtkZKmxsfOhAJiO0kvAN+M08455+okyxnFdsBPi+btVGJewSXAI5IKd3LvSThTSGVm91O+QNm2cpjOOedqIW3gosOBHxKGQE02RvcGHii3npmdKakV+EacdbCZPVGFWJ1zznWBtDOKq4BbgT+w6E1u88zs3bSNxvshHu98eM4557paWkFhZjZT0hHFCyStXKmwcM45t3SodEaxK+HOamPR9gMDvljDuNwSoj2XIDrnlkxpQ6HuGp+H1S8c55xzeZPWmL1p2oqFfpmcc84t3dKqns5IWWbAyCrH4pxzLofSqp5a6hmIc865fEqrehppZndJ2qvUcjO7vtR855yrFr9YIh/Sqp62Ae4CdiuxzFjY6Z9zzrmlWFrV00nx+eD6heOccy5vsgyFOkDSOZIelzRF0tlxbArnnHPLgCy9x44H3gK+DewdX0+oZVDOOefyI0vvsYPM7HeJ6VMk7VurgJxzzuVLljOKOyR9V1K3+NgHuL3WgTnnnMuHtMtj57Gwj6djgSviom5AG3BCrYNzzjnX9dKueupdz0Ccc87lU6YRzyX1B9YBVizMKx4e1Tnn3NIpy+Wx3wfuJbRL/CY+n1ztQCRdLOlNSU8n5q0s6U5JL8Tn/tXO1znnXLosjdnHAF8FXon9P20CzK1BLJcCOxbNOxGYZGbrAJNYdKQ955xzdZCloPivmf0XQNIKZvYvYL1qBxKrsopHzdsDGBdfjwP2rHa+zjnn0snM0hNINwAHE658Ggm8ByxnZjtXPRhpKHCzmX0lTs81s37xtYD3CtNF640BxgA0NjaOGD9+fLVDK6mtrY2Ghoa65NVRtY5x2qz3O7V+Y0+Y81GVgqmRvMfo8XVecYzDB/ftumBKqMdvTUtLyxQzayq1rGJBsUhiaRugL3CbmX1SpfiS2x9KmYIiTr9nZqntFE1NTTZ58uRqh1ZSa2srzc3Ndcmro2odY2d79zx++HzOmJbpmoouk/cYPb7OK45x5thdujCaxdXjt0ZS2YIi61VPmwLfINxX8UAtCoky5kgaZGazJQ0C3qxTvkuUtB/r44fPZ3SFH/O8fSmcW9J15g9UHr+PWa56+jWhfWAAMBC4RNIvax1YNBEYFV+PAm6sU77OOeeiLGcU+wMbJRq0xwJTgVOqGYikq4FmYKCk14CTgLHANZIOBV4B9qlmns455yrLUlC8TrjR7r9xegVgVrUDMbP9yizattp5Oeecyy6tr6dzCW0S7wPPSLozTm8HPFqf8JxzznW1tDOKwqVDU4AbEvNbaxaNc87lgI/Vvai0TgELN7ohaXlg3Tg53cw+rXVgzjnn8qFiG4WkZsJVTzMJXY4PkTTKOwV0zrllQ5bG7DOA7c1sOoCkdYGrgRG1DMw551w+ZCkolisUEgBm9ryk5WoYk6szr491zqXJUlBMkfR3Fo5wtz8LG7qdc84t5bIUFIcBRwBHx+n7gPNqFpFzzrlcSS0oJHUHnjSz9YEz6xOSc865PEnt68nMPgOmS1qjTvE455zLmSxVT/0Jd2Y/CnxYmGlmu9csqi7Unobd4p5ZO9ProzcoO+eg9G9Bll6goXY9z2YpKH5Vk5ydc84tEdL6elqR0JC9NjANuMjM5tcrMOecc/mQ1kYxDmgiFBI7EW68c845t4xJq3rawMyGA0i6CO8x1jnnlklpBcWCjv/MbL6kOoSzZPMGaefc0iitoNhI0gfxtYCecVqAmVmfmkfnnHOuy5VtozCz7mbWJz56m1mPxOu6FhKSdpQ0XdKLkk6sZ97OObesS73hLg/i3eF/ITSobwDsJ2mDro3KOeeWHbkvKIDNgBfNbIaZfQKMB/bo4picc26ZITPr6hhSSdob2NHMvh+nDwS+ZmZHJtKMAcbEyfWA6YttqDYGAm/XKa+OynuMeY8P8h+jx9d5eY+xHvGtaWarlFqQ5c7s3DOzC4EL652vpMlm1lTvfNsj7zHmPT7If4weX+flPcaujm9JqHqaBQxJTK8e5znnnKuDJaGgeAxYR9IwScsD3wUmdnFMzjm3zMh91VO82e9I4HagO3CxmT3TxWEV1L26qwPyHmPe44P8x+jxdV7eY+zS+HLfmO2cc65rLQlVT84557qQFxTOOedSeUGRUKmrEElrSpok6SlJrZJWTyw7XdIzkp6TdI5iL4ox3XRJU+Nj1S6K7zRJT8fHvon5wyQ9Erc5IV4wkKf4LpX0cmL/bdyJ+C6W9Kakp8ssV/zsXowxbppYNkrSC/ExKjF/hKRpcZ0Fn3vOYqzmMdiZ+G6TNFfSzUXrVO0YrGGMXX4cStpY0kMKvzNP1ep7XJKZ+SO003QHXgK+CCwPPEnoaj2Z5lpgVHw9Erg8vv468EDcRnfgIaA5LmsFmro4vl2AOwkXL/QiXEnWJy67BvhufH0BcHjO4rsU2LtKn/HWwKbA02WW7wzcSuj4cnPgkTh/ZWBGfO4fX/ePyx6NaRXX3SmHMVblGOxMfHHZtsBuwM1F61TlGKxxjHk4DtcF1omvVwNmA/1qsQ+LH35GsVCWrkI2AO6Kr+9OLDdgRcIP5ArAcsCcHMW3AXCvmc03sw+Bp4Ad47/fkcB1Md04YM+8xNfBOMoys3uBd1OS7AFcZsHDQD9Jg4AdgDvN7F0ze49QqO0Yl/Uxs4ctfEMvo+P7ryYxdiaWKseHmU0C5iUTV/kYrEmM1dbR+MzseTN7IW7jdeBNYJVa7MNiXlAsNBj4d2L6tTgv6Ulgr/j6W0BvSQPM7CHCD9/s+LjdzJ5LrHdJPF39VSeqJjocX5y/o6SVJA0EWgg3MQ4A5trCIW5LbbMr4ys4NZ5qnyVphQ7Gl0W595A2/7US82upvTEWVOMY7Ex85VTzGMyqvTEWdPVxuICkzQh/TF+iDvvQC4r2OQHYRtITwDaEO8Q/k7Q28CXCXeODgZGStorr7G9hpMCt4uPAesdnZncA/w94ELiaUDX2WQ3jqGZ8PwPWB75KqFb5ab2DXgrU8xhcWuXmOIxnP5cDB5vZ5/XI0wuKhSp2FWJmr5vZXma2CfCLOG8u4d/xw2bWZmZthPrFLeLyWfF5HnAVoYqm3vFhZqea2cZmth2h7vN54B3CaW2Pctvs4vgws9nxFPxj4BI6vv868x7S5q9eYn4ttTfGah6DnYmvnGoeg1m1u1ugnByHSOoD3AL8IlZLQR32oRcUC1XsKkTSQEmFffYz4OL4+lXCP+UekpYj/Ft+Lk4PjOsuB+wKlLzSoZbxSeoeq3iQtCGwIXBHrFe/G9g7rjMKuDEv8cXpQfFZhHrXju6/LCYCB8WrTjYH3jez2YReAbaX1F9Sf2B7QvXibOADSZvH+A6i4/uvJjFW+RjsTHwlVfkYrEmMkI/jMH6vbiC0XxTaI+qzDzvbGr40PQhXGzxPqPf7RZz3W2D3+Hpv4IWY5u/ACnF+d+CvwHPAs8CZcX4vYAqhcfYZ4GygexfEt2KM61ngYWDjxDa/SLhy50XCVUkr5Cy+u4BphC/mFUBDJ+K7mtCG9CmhHvdQ4DDgsLhchEGyXop5NiXWPSTuoxcJp/yF+U0xtpeAPxN7O8hLjDU4BjsT333AW8BHcd0dqn0M1jDGLj8OgQPiOlMTj41rsQ+LH96Fh3POuVRe9eSccy6VFxTOOedSeUHhnHMulRcUzjnnUnlB4ZxzLtVSXVBIGqCFvT2+IWlWYtokXZFI20PSW4q9RkoaHaenSvqXpOMSaU8u2tZUSf0kNauo18kav7+hkr6XmG6SdE698q+meu+7jpD086LpB9u5/tEKvQtf2cH8uyn0Kvq0Qo+1j0kaFpf1lXSZQu+hL0m6Mt5PUThOFrvuX6FH1FmK3VHE+1xmVsor7xR6y23q6jjyLP6GnZA1/VJdUJjZOxbu9t2Y0KPiWYnpD4GvSOoZk2/H4nczTohptwR+ISl5t+SCbcXH3Fq+lzKGAgsKCjObbGZH1ytzLbwTdKmQ4f0sUlCY2dfbmcUPge3MbP8OxrMvodfQDS10yfEtYG5cdhEww8zWNrO1CNfTX5ohm88I918US8ur7pa2Y60W4g16NflNX6oLigz+H6GLa4D9CDfCLMbM3iF88QZ1JjNJq0qaEl9vFM9q1ojTLyl0irebQr/yT0j6p6TGuHybxNnLE5J6A2OBreK845L/yuM/hovjv6sZko5OxPErhfEJ7pd0dal/FvHf5gWSJkt6XtKucf5oSRMl3QVMktQr5vNojGuPmO5hSV9ObK81nvFsptCn/hOSHpS0Xom8y21ztKTrFcYMeEHS6Yl1dpT0uKQnJU1K205RXs2S7pM0kXDDH5L+T9IUhX7/x8R5Y4GecV9fGee1xWdJ+mPi3/e+JfK5gHBT1K3xs1o55vNU3FcbJj63yyU9QOjPJ2kQMNti/z5m9pqZvafQ19gI4HeJtL8FNiq1f4v8CTiuxA9xybxKvK+vxs/xybife0taUdIlcV88Iaklpi13TKR93lmOtZ6Sxiucrd0A9CwR546Srk1MN0u6WaFXgEsTn91xxesWbWe0pD8npm+W1Bxft0k6Ne6Lh7Xwu9so6YY4/0lJX4/zf6SFY7AcG+eNlXREYvsL/vlL+rHCmd1Tkn4T5w1V+C5fRrgZcEipdDHtLxS+y/cDlY6LRVXz7r08P4CTgRMS022EriKuI9wZPBVoJvZDD4wG/hxfrxGXr5jY1iwW3h15d5y/YP2UOJ4B+gBHErq92B9YE3goLu8PC26E/D5wRnx9E7BlfN1AGLthkfyK4j+Z0MneCsBAQn8wyxE6NZsa33Nvwp3SJ5SI81LgNsKfiXUId5CuGPfLa8DKMd3vgQPi636Eu657AccBv4nzBwHT4+s+QI/4+pvAP0rEXm6bownjLPSNsbxC6BNnFUJvm8PiOqmxFb3PZsLZ5bDEvML6PQlfvgGFY6Zo3bb4/G1Ct97dgUZCly6DSuzTmcDA+Ppc4KT4eiQwNfG5TQF6llh/9biNqcAZwCZx/u7ADSXS30DobmIoJcY+iJ/x3oSuVA4mHCcz0/IqWn/5+Hl8NfnZAscDF8d568f9sWLKMZH2eWc51n6UyG9DYD5F42/EuF4tfP7A+YQ7nUcQumcvpOtX4fs7mvi7EKdvZuHYMwbsFl+fDvwyvp4AHBtfdyccvyMId133InyfnwE2iY97Ett/lnCMbw9cSLhru1vMd+v42X4ObB7Tl0tXyG+l+Dm9SInvfbnHMn1GYWZPEXb0foSzi2L7SnqKsFPPM7P/JpadZQurnVrake2DhKqsrQkH/taEHj3vi8tXJ/TRMw34MVD4B/YAcKbCmUE/W9ilcJpbzOxjM3ub0Hd9Y8z7RjP7r4VO4m5KWf8aM/vcQh/4MwhfeojjHsTX2wMnSppKGCBnRULBeg0L+57Zh4V95fcFrlWoMz8r8f6Sym0TYJKZvR8/i2cJhezmhPEsXgbIEFuxRwvrRkdLepLQncgQQkGZ5hvA1Wb2mZnNAe4hFMiV1rk8xnsXMEChwzeAiWb2UfEKZvYa4Z/gzwg/DpMkbVshnyz+QDjWFvweZMxrPcJZx2NxnQ/icfkNQjcXmNm/CAX6upQ/JtI+pyzH2taJ/J4idFeyiBjXbcBu8expF0J/SDOAL0o6V9KOwAcZ9lc5nxB+mCEU9kPj65GEgol4jLxP2Ec3mNmHFjoSvR7YysyeAFaVtJqkjYD3zOzf8b1vDzwBPE74LhaOy1dsYQeB5dJtFfP7j5l9QFE/bJV4vV/YYf9L+Gc5oGjZBDM7UqFh7A5JE83sjU7mdy/hQ1uTcKD+lPBP5Ja4/FxCX1ET4yntyQBmNlbSLYT+lB6QtEOGvD5OvP6M9n/exf27FKY/TMwT8G0zm168sqR3YpXKvoS+bCBUj9xtZt+SNJTwhV9s1VLblPQ12veeysZWZMH7ifv8m8AWZvYfSa2EH6R6+rDcAgu9l95KqMKaQzhjOBvYWFI3i1VFCnXVGxF+LFL/EJrZC/HHd58MeU3q2FsKvdiWOSbSPu+Kx5qyD68xnnAm/y4wOf5RIv4g7xDj2YfSbTYF81l0fyaPjU8t/q2nY9+3gmsJBeoXCGcjEN77H8zsr8mE8TtUvI9KpTu2g7EA3kYB4bT7N2Y2rVwCM5tM+Pd3TBXyu49wyvtC/FK/S/jxvz8u78vCRvVRhZUkrWVm08zsNEKV1fqEkbh6tzP/Bwj/qlaU1EDoTbSc7yhc/bIWoX691A/u7cBR0oIxwjdJLJsA/AToG//pFb+/0WXyTdtmKQ8DW2vhFUArd3A7hfjei4XE+oSzlYJPFXpgLXYf4eyzu6RVCP9wH62Qz32EasdC4fR2/KdXlqRNJa0WX3cjVLO8YmYvEv5B/jKR/JeEs69XK8RRcCphvJDUvIrWmQ4MkvTVmK53/LeefG/rEv71F46dUsdE1s+pXLp7iRd1SPpKjLWUewhDkP4PodBAoWfdbmb2D8I+27TMugUziYWywsUtWbobnwQcHvPrLqkvYR/tqdAu2YtwsUChVmECofflvQmFRuG9HxK/s0garNJjn5dLd2/Mr6dC++ZuGeJeYJkvKCw00mW5pPQ04OC4kyE0ACYvjx0a528r6bXEY4ui/GYSSv1746z7CaNTFRoKTyZUzUwB3k6semxs9HqK0IPkrYRT7M8UGshSG+ES+T9GOIt6Km5jGvB+meSvEn7wbiX0bPnfEml+R2j7eErSMyzaoHod4YC/JjHvdOAPCoMXlfvHlbbNUu/pLWAMcH2sMir8C2vXdqLbgB6SniNcLPBwYtmFcVvFl7feQNifTxJ6Gf1JhjPPk4ER8fMcS+JPQYpVgZtitd1ThH+3hYbVQwjdvL8k6S1CAXdYYt31io7L7yQ3bGbPEM4+suRVWOcTwpnBuXG/30n4h30e0C1Wn04ARsezEyh9TGT9nMqlOx9oiJ/ZbwnVPosxs88IVUM7sbCKaDDQGs+oriBUtSHpMEmHldjMA8DLhGrPc1h0n5VzDNAS98cUwljyjxPaiB4FHgH+HqudCp9Fb2CWxe7PLQzudRXwUNzOdZT4k1guXcxvAuEYvZXwZzMz7z12GSSpwczaJK1EKLDGxAMpmeZSQuPydaW24fJL4UqnW4CjzaxU25tz7eJtFMumCyVtQPj3N664kHBLtliHv3ZXx+GWHn5G4ZxzLtUy30bhnHMunRcUzjnnUnlB4ZxzLpUXFM4551J5QeGccy7V/wccPhASfMeQOQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "wasting_prevalence_ratio.query(\"wasting_state == 'susceptible_to_child_wasting'\").value.hist(bins=20, density=True)\n",
+    "plt.xlabel(\"TMREL wasting prevalence ratio for SQLNS covered vs. uncovered\")\n",
+    "plt.ylabel(\"Probability density over 288 combinations\\nof (year, sex, age, draw)\")\n",
+    "plt.title(\"TMREL wasting prevalence ratio historgrm\");"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0760c58e",
+   "id": "9e45c11c",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Continuation of model 3.1 V&V. New takeaways:

1. Validation: The MAM prevalence ratio for SQLNS-covered vs. SQLNS-uncovered does **not** quite match the incidence ratio of 0.82 that we applied to MAM incidence; it's closer to 0.87. (I haven't yet verified that the incidence ratio is being applied correctly -- I'll do that next.)
2. Validation: SAM prevalence decreased by a factor of about 0.89 with SQLNS. Does this seem reasonable? Literature found no effect on SAM, so we don't have a specified target here.
3. Verification: The mean effect size of SQLNS on stunting prevalence matches what we want, but the parameter uncertainty seems to be smaller than expected. However, I'm not sure whether I'm interpreting the data correctly -- see comments in notebook.