### PR TITLE
Update handling of cause person time

### DIFF
--- a/model_validation/ciff_sam_results.py
+++ b/model_validation/ciff_sam_results.py
@@ -217,6 +217,15 @@ def extract_transition_states(transition_df):
     )
     return states_df
 
+def assert_cause_person_time_equal(data):
+    """Raise an AssertionError if different cause state observers recorded different amounts of total person-time."""
+    cause_person_time = get_total_person_time(data, 'cause')
+    first_cause, *remaining_causes = cause_person_time.cause.unique()
+    person_time = cause_person_time.query("cause==@first_cause").drop(columns='cause')
+    # Check that total person-time is the same for all causes
+    for cause in remaining_causes:
+        vop.assert_values_equal(person_time, cause_person_time.query("cause==@cause").drop(columns='cause'))
+
 def age_to_ordered_categorical(df, inplace=False):
     if inplace:
         df['age'] = df['age'].astype(ordered_ages_dtype)


### PR DESCRIPTION
- Remove calculation of total person time from cause state person time in data cleaning step, because (1) person-time was recorded directly in models before wasting state person time was added, and (2) the existing method was incorrect since it duplicated the total person time for each cause.
- Add an `assert_cause_person_time_equal` function to verify that total recorded person time is equal for all cause state observers.